### PR TITLE
Add postgres backend as enterprise option

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an open source observability pipeline.
 type: application
 # The chart's version
-version: 0.0.7
+version: 0.0.8
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.8.0

--- a/charts/bindplane/templates/_helpers.tpl
+++ b/charts/bindplane/templates/_helpers.tpl
@@ -29,7 +29,7 @@ The image to use
 */}}
 {{- define "bindplane.image" -}}
 {{- if eq .Values.enterprise true -}}
-{{- printf "%s:%s" .Values.image.repository (default (printf "%s-ee" .Chart.AppVersion) .Values.image.tag) }}
+{{- printf "%s-ee:%s" .Values.image.repository (default (printf "%s" .Chart.AppVersion) .Values.image.tag) }}
 {{- else -}}
 {{- printf "%s:%s" .Values.image.repository (default (printf "%s" .Chart.AppVersion) .Values.image.tag) }}
 {{- end -}}

--- a/charts/bindplane/templates/_helpers.tpl
+++ b/charts/bindplane/templates/_helpers.tpl
@@ -28,7 +28,11 @@ If release name contains chart name it will be used as a full name.
 The image to use
 */}}
 {{- define "bindplane.image" -}}
+{{- if eq .Values.enterprise true -}}
+{{- printf "%s:%s" .Values.image.repository (default (printf "%s-ee" .Chart.AppVersion) .Values.image.tag) }}
+{{- else -}}
 {{- printf "%s:%s" .Values.image.repository (default (printf "%s" .Chart.AppVersion) .Values.image.tag) }}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -87,11 +87,32 @@ spec:
               {{- end }}
             - name: BINDPLANE_CONFIG_LOG_OUTPUT
               value: stdout
-            # Write everything to the persistent volume
             - name: BINDPLANE_CONFIG_HOME
-              value: /data
+              value: /data  
+            {{- if and (eq .Values.enterprise true) (eq .Values.backend.type "postgres") }}
+            - name: BINDPLANE_CONFIG_STORE_TYPE
+              value: postgres
+            - name: BINDPLANE_CONFIG_POSTGRES_HOST
+              value: {{ .Values.backend.postgres.host }}
+            - name: BINDPLANE_CONFIG_POSTGRES_PORT
+              value: "{{ .Values.backend.postgres.port }}"
+            - name: BINDPLANE_CONFIG_POSTGRES_USERNAME
+              value: {{ .Values.backend.postgres.username }}
+            - name: BINDPLANE_CONFIG_POSTGRES_PASSWORD
+              value: {{ .Values.backend.postgres.password }}
+            - name: BINDPLANE_CONFIG_POSTGRES_DATABASE
+              value: {{ .Values.backend.postgres.database }}
+            - name: BINDPLANE_CONFIG_POSTGRES_SSLMODE
+              value: {{ .Values.backend.postgres.sslmode }}
+            - name: BINDPLANE_CONFIG_POSTGRES_MAX_CONNECTIONS
+              value: "{{ .Values.backend.postgres.maxConnections }}"
+            {{- else }}
+            - name: BINDPLANE_CONFIG_STORE_TYPE
+              value: bbolt
             - name: BINDPLANE_CONFIG_STORAGE_FILE_PATH
               value: /data/storage
+            {{- end }}
+
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -1,12 +1,24 @@
+enterprise: false
+
 # Backend to use for persistent storage. When set to `file`, bindplane will be
 # deployed as a single pod statefulset using a persistent volume.
 backend:
   type: bbolt
+
   bbolt:
     volumeSize: 10Gi
 
+  postgres:
+    host: localhost
+    port: 5432
+    database: ""
+    sslmode: "disable"
+    username: ""
+    password: ""
+    maxConnections: 100
+
 image:
-  repository: observiq/bindplane
+  repository: ghcr.io/observiq/bindplane
   # Overrides the image tag whose default is {{ .Chart.AppVersion }}
   tag: ""
 


### PR DESCRIPTION
- Bumped chart version
- Added condition to helper for selecting the correct image repo
- Added all Postgres options, usable when enterprise is enabled and Postgres is set as the backend type
  - bolt store is used when enterprise is not enabled or if postgres is not selected as the backend
- switch to ghcr.io instead of dockerhub, as ghcr.io hosts both open source and enterprise editions of bindplane

When bbolt is not the backend, a deployment is generated instead of a statefulset (this was already implemented). Deployments look similar but have the following changes
- kind: Deployment
- serviceName is no longer set

When enterprise is enabled and postgres is set as the backend, the following diff is expected
- kind: Deployment
- serviceName is no longer set
- image name is `bindplane-ee`
- env:
  - store type value is postgres instead of bbolt
  - all seven postgres options are set
- volume mount and volume claim templates no longer generated because bindplane is running in a "stateless" mode

## Testing

### Diff

You can test with the following `test.yaml`
```yaml
enterprise: true
backend:
  type: postgres
  postgres:
    host: postgres
    username: root
    password: password
    database: bindplane
image:
  # latest enterprise build
  tag: 5ad9b2e
```
compare the two
```bash
helm template test charts/bindplane > bolt.yaml
helm template test --values test.yaml charts/bindplane > pg.yaml

diff bolt.yaml pg.yaml
```

### Minikube / K3D

You can test against a live cluster by deploying postgres:

```yaml
apiVersion: v1
kind: Service
metadata:
  labels:
    app: postgres
  name: postgres
spec:
  ports:
  - port: 5432
    protocol: TCP
    targetPort: postgres
    name: postgres
  selector:
    app: postgres
  sessionAffinity: None
  type: ClusterIP
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: postgres
spec:
  selector:
    matchLabels:
      app: postgres
  strategy:
    type: Recreate
  template:
    metadata:
      labels:
        app: postgres
    spec:
      containers:
      - image: postgres:14.0
        name: postgres
        env:
        - name: POSTGRES_USER
          value: root
        - name: POSTGRES_PASSWORD
          value: password
        - name: POSTGRES_DB
          value: bindplane
        ports:
        - containerPort: 5432
          name: postgres
```

While connected to your cluster, deploy bindplane with the values file you created previously

```bash
helm template test --values test.yaml charts/bindplane | k apply -f - 
```

Bindplane will fail to start if postgres is not deployed. If postgres is deployed, bindplane will log it and run without issue:
```bash
➜  bindplane-op-helm git:(feat/postgres-backend) ✗ kubectl logs deploy/test-bindplane                                                       

{"level":"info","timestamp":"2023-02-13T23:22:40.917Z","message":"Using Postgres backend"}
```
