### PR TITLE
feat: Support ldap auth (Enterprise)

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an open source observability pipeline.
 type: application
 # The chart's version
-version: 0.0.9
+version: 0.0.10
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.8.0

--- a/charts/bindplane/templates/_helpers.tpl
+++ b/charts/bindplane/templates/_helpers.tpl
@@ -48,3 +48,16 @@ remote storage option is selected, run as a Deployment.
 {{- printf "%s" "Deployment" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Merge ldap and active-directory into one auth type because they
+have identical configuration as of right now. This makes it easier to check for
+instead of checking 'if ldap || active-directory'.
+*/}}
+{{- define "bindplane.auth.type" -}}
+{{- if or (eq .Values.auth.type "ldap") (eq .Values.auth.type "active-directory") -}}
+{{- printf "%s" "ldap" }}
+{{- else }}
+{{- printf "%s" "system" }}
+{{- end -}}
+{{- end -}}

--- a/charts/bindplane/templates/_helpers.tpl
+++ b/charts/bindplane/templates/_helpers.tpl
@@ -58,6 +58,6 @@ instead of checking 'if ldap || active-directory'.
 {{- if or (eq .Values.auth.type "ldap") (eq .Values.auth.type "active-directory") -}}
 {{- printf "%s" "ldap" }}
 {{- else }}
-{{- printf "%s" "system" }}
+{{- printf "%s" .Values.auth.type }}
 {{- end -}}
 {{- end -}}

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -130,7 +130,11 @@ spec:
             - name: BINDPLANE_CONFIG_LDAP_SERVER
               value: {{ .Values.auth.ldap.server }}
             - name: BINDPLANE_CONFIG_LDAP_PORT
-              value: "{{ .Values.auth.ldap.port }}"
+              {{- if eq .Values.auth.ldap.protocol "ldaps"}}
+              value: {{ .Values.auth.ldap.port | default (printf "%s" "1636" ) }}
+              {{- else }}
+              value: {{ .Values.auth.ldap.port | default (printf "%s" "1389" ) }}
+              {{- end }}
             - name: BINDPLANE_CONFIG_LDAP_BASE_DN
               value: {{ .Values.auth.ldap.baseDN }}
             - name: BINDPLANE_CONFIG_LDAP_BIND_USER

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -122,6 +122,32 @@ spec:
               value: /credentials.json
             {{- end }}
             {{- end }}
+            {{- if and (eq .Values.enterprise true) (eq .Values.auth.type "ldap") }}
+            - name: BINDPLANE_CONFIG_AUTH_TYPE
+              value: {{ .Values.auth.type }}
+            - name: BINDPLANE_CONFIG_LDAP_PROTOCOL
+              value: {{ .Values.auth.ldap.protocol }}
+            - name: BINDPLANE_CONFIG_LDAP_SERVER
+              value: {{ .Values.auth.ldap.server }}
+            - name: BINDPLANE_CONFIG_LDAP_PORT
+              value: "{{ .Values.auth.ldap.port }}"
+            - name: BINDPLANE_CONFIG_LDAP_BASE_DN
+              value: {{ .Values.auth.ldap.baseDN }}
+            - name: BINDPLANE_CONFIG_LDAP_BIND_USER
+              value: {{ .Values.auth.ldap.bindUser }}
+            - name: BINDPLANE_CONFIG_LDAP_BIND_PASSWORD
+              value: {{ .Values.auth.ldap.bindPassword }}
+            - name: BINDPLANE_CONFIG_LDAP_SEARCH_FILTER
+              value: {{ .Values.auth.ldap.searchFilter }}
+            {{- if .Values.auth.ldap.tls.ca.secret }}
+            - name: BINDPLANE_CONFIG_LDAP_TLS_CA
+              value: /ldap-ca.crt
+            {{- end }}
+            {{- if .Values.auth.ldap.tls.insecure }}
+            - name: BINDPLANE_CONFIG_LDAP_TLS_INSECURE
+              value: "true"
+            {{- end }}
+            {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -158,6 +184,13 @@ spec:
               subPath: {{ .Values.eventbus.pubsub.credentials.subPath }}
             {{- end }}
             {{- end }}
+            {{- if and (eq .Values.enterprise true) (eq .Values.auth.type "ldap") }}
+            {{- if .Values.auth.ldap.tls.ca.secret }}
+            - mountPath: /ldap-ca.crt
+              name: {{ .Values.auth.ldap.tls.ca.secret }}
+              subPath: {{ .Values.auth.ldap.tls.ca.subPath }}
+            {{- end }}
+            {{- end }}
           lifecycle:
             preStop:
               exec:
@@ -170,6 +203,14 @@ spec:
           secret:
             defaultMode: 0400
             secretName: {{ .Values.eventbus.pubsub.credentials.secret }}
+        {{- end }}
+        {{- end }}
+        {{- if and (eq .Values.enterprise true) (eq .Values.auth.type "ldap") }}
+        {{- if .Values.auth.ldap.tls.ca.secret }}
+        - name: {{ .Values.auth.ldap.tls.ca.secret }}
+          secret:
+            defaultMode: 0400
+            secretName: {{ .Values.auth.ldap.tls.ca.secret }}
         {{- end }}
         {{- end }}
   {{- if eq (include "bindplane.deployment_type" .) "StatefulSet" }}

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -122,7 +122,7 @@ spec:
               value: /credentials.json
             {{- end }}
             {{- end }}
-            {{- if and (eq .Values.enterprise true) (eq .Values.auth.type "ldap") }}
+            {{- if and (eq .Values.enterprise true) (eq (include "bindplane.auth.type" .) "ldap") }}
             - name: BINDPLANE_CONFIG_AUTH_TYPE
               value: {{ .Values.auth.type }}
             - name: BINDPLANE_CONFIG_LDAP_PROTOCOL
@@ -138,7 +138,11 @@ spec:
             - name: BINDPLANE_CONFIG_LDAP_BIND_PASSWORD
               value: {{ .Values.auth.ldap.bindPassword }}
             - name: BINDPLANE_CONFIG_LDAP_SEARCH_FILTER
-              value: {{ .Values.auth.ldap.searchFilter }}
+              {{- if eq .Values.auth.type "active-directory"}}
+              value: {{ .Values.auth.ldap.searchFilter | default (printf "%s" "(|(sAMAccountName=%[1]v)(userPrincipalName=%[1]v))" ) }}
+              {{- else}}
+              value: {{ .Values.auth.ldap.searchFilter | default (printf "%s" "(uid=%s)" ) }}
+              {{- end }}
             {{- if .Values.auth.ldap.tls.ca.secret }}
             - name: BINDPLANE_CONFIG_LDAP_TLS_CA
               value: /ldap-ca.crt
@@ -184,7 +188,7 @@ spec:
               subPath: {{ .Values.eventbus.pubsub.credentials.subPath }}
             {{- end }}
             {{- end }}
-            {{- if and (eq .Values.enterprise true) (eq .Values.auth.type "ldap") }}
+            {{- if and (eq .Values.enterprise true) (eq (include "bindplane.auth.type" .) "ldap") }}
             {{- if .Values.auth.ldap.tls.ca.secret }}
             - mountPath: /ldap-ca.crt
               name: {{ .Values.auth.ldap.tls.ca.secret }}
@@ -205,7 +209,7 @@ spec:
             secretName: {{ .Values.eventbus.pubsub.credentials.secret }}
         {{- end }}
         {{- end }}
-        {{- if and (eq .Values.enterprise true) (eq .Values.auth.type "ldap") }}
+        {{- if and (eq .Values.enterprise true) (eq (include "bindplane.auth.type" .) "ldap") }}
         {{- if .Values.auth.ldap.tls.ca.secret }}
         - name: {{ .Values.auth.ldap.tls.ca.secret }}
           secret:

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -131,9 +131,9 @@ spec:
               value: {{ .Values.auth.ldap.server }}
             - name: BINDPLANE_CONFIG_LDAP_PORT
               {{- if eq .Values.auth.ldap.protocol "ldaps"}}
-              value: {{ .Values.auth.ldap.port | default (printf "%s" "1636" ) }}
+              value: "{{ .Values.auth.ldap.port | default (printf "%s" "1636" ) }}"
               {{- else }}
-              value: {{ .Values.auth.ldap.port | default (printf "%s" "1389" ) }}
+              value: "{{ .Values.auth.ldap.port | default (printf "%s" "1389" ) }}"
               {{- end }}
             - name: BINDPLANE_CONFIG_LDAP_BASE_DN
               value: {{ .Values.auth.ldap.baseDN }}

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -37,6 +37,40 @@ eventbus:
       # Secret subPath which contains the Google Cloud credential JSON
       subPath: ""
 
+auth:
+  # Supported options:
+  # - system (basic auth)
+  # - ldap (openldap, active directory, etc)
+  # 'system' will use the username and password specified
+  # in config.secret or config.username / config.password.
+  type: system
+
+  ldap:
+    # ldap or ldaps (tls)
+    protocol: ldap
+    server: ""
+    # Common options are 1389 (plain text) and 1636 (tls)
+    port: 1389
+    # Example: ou=users,dc=stage,dc=net
+    baseDN: ""
+    # Example: cn=admin,dc=stage,dc=net
+    bindUser: ""
+    bindPassword: ""
+    searchFilter: (uid=%s)
+    tls:
+      # Set to true to skip verification of the ldap server's certificate
+      insecure: false
+      # Secret name and key which has the ldap server's certificate authority public certificate.
+      # You can create the secret with:
+      #   kubectl create secret generic ldap-ca --from-file ./ca.crt
+      # And use the following values:
+      #  ca:
+      #    name: ldap-ca
+      #    subPath: ca.crt
+      ca:
+        secret: ""
+        subPath: ""
+
 image:
   # TODO(jsirianni): break repository into 'repository' and 'image'
   # or rename repository to image.

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -1,27 +1,38 @@
+# -- Whether or not enterprise edition is enabled. Enterprise users require a valid Enterprise subscription.
 enterprise: false
 
-# Backend to use for persistent storage. When set to `file`, bindplane will be
-# deployed as a single pod statefulset using a persistent volume.
 backend:
+  # -- Backend to use for persistent storage. Available options are `bbolt`, and `postgres` (Enterprise).
   type: bbolt
 
   bbolt:
+    # -- Persistent volume size.
     volumeSize: 10Gi
 
   postgres:
+    # -- Hostname or IP address of the Postgres server.
     host: localhost
+    # -- TCP port used to connect to Postgres.
     port: 5432
+    # -- Database to use.
     database: ""
+    # -- SSL mode to use when connecting to Postgres over TLS. See the [postgres ssl documentation](https://jdbc.postgresql.org/documentation/ssl/) for valid options.
     sslmode: "disable"
+    # -- Username to use when connecting to Postgres.
     username: ""
+    # -- Password for the username used to connect to Postgres.
     password: ""
+    # -- Max number of connections to use when communicating with Postgres.
     maxConnections: 100
 
 eventbus:
+  # Enterprise only option. The eventbus type to use using multiple nodes. Available options include `pubsub`.
   type: ""
 
   pubsub:
+    # Project ID that should be used for connecting to the Pub/Sub API.
     projectid: ""
+    # Pub/Sub topic to use.
     topic: ""
     # Credentials are required when running outside of Google Cloud
     # or when the GKE / GCE instance is not configured with the
@@ -32,9 +43,9 @@ eventbus:
     #     secret: bindplane-pubsub
     #     subPath: credentials.json
     credentials:
-      # Secret name
+      # -- Optional Kubernetes secret which contains Google Cloud JSON service account credentials. Not required when running within Google Cloud with the Pub/Sub scope enabled.
       secret: ""
-      # Secret subPath which contains the Google Cloud credential JSON
+      # -- Sub path for the secret which contains the Google Cloud credential JSON
       subPath: ""
 
 auth:
@@ -44,25 +55,27 @@ auth:
   # - active-directory
   # 'system' will use the username and password specified
   # in config.secret or config.username / config.password.
+  # -- Backend to use for authentication. Available options include `system`, `ldap` (Enterprise) and `active-directory` (Enterprise).
   type: system
 
+  # -- Configuration options for 'ldap' and 'active-directory' authentication backends.
   ldap:
-    # ldap or ldaps (tls)
+    # -- Protocol to use. Available options include `ldap` (plain text) and `ldaps` (tls).
     protocol: ldap
+    # -- Hostname or IP address of the ldap server.
     server: ""
-    # Common options are 1389 (plain text) and 1636 (tls)
-    port: 1389
-    # Example: ou=users,dc=stage,dc=net
+    # -- TCP port to use when connecting to the ldap server. Defaults to `1389` (plain text) or `1636` (tls).
+    port:
+    # -- Base DN to use when looking up users. Example: `ou=users,dc=stage,dc=net`.
     baseDN: ""
-    # Example: cn=admin,dc=stage,dc=net
+    # -- User to use when looking up users. Example: `cn=admin,dc=stage,dc=net.`
     bindUser: ""
+    # -- Password to use for the bind user.
     bindPassword: ""
-    # default values
-    # - ldap: (uid=%s)
-    # - active-directory: (|(sAMAccountName=%[1]v)(userPrincipalName=%[1]v))
+    # -- Search filter to use when looking up users. Defaults to `(uid=%s)` (ldap) and `(|(sAMAccountName=%[1]v)(userPrincipalName=%[1]v))` (active-directory).
     searchFilter: ""
     tls:
-      # Set to true to skip verification of the ldap server's certificate
+      # -- Whether or not to skip verification of the ldap server's certificate.
       insecure: false
       # Secret name and key which has the ldap server's certificate authority public certificate.
       # You can create the secret with:
@@ -72,14 +85,18 @@ auth:
       #    name: ldap-ca
       #    subPath: ca.crt
       ca:
+        # -- Name of the Kubernetes secret which contains the ldap server's certificate authority public certificate.
         secret: ""
+        # -- The secret's subPath which contains the certificate.
         subPath: ""
 
 image:
   # TODO(jsirianni): break repository into 'repository' and 'image'
   # or rename repository to image.
+  # -- Repository and image to use.
   repository: ghcr.io/observiq/bindplane
   # Overrides the image tag whose default is {{ .Chart.AppVersion }}
+  # -- Image tag to use. Defaults to the version defined in the Chart's release.
   tag: ""
 
 # Bindplane configuration options:
@@ -89,12 +106,14 @@ config:
   # clusterIP service. If you wish to communicate with bindplane-op through an ingress
   # service such as ingress-nginx, replace this value with the protocol (http / https), 
   # hostname, path, and port defined in your ingress rule.
+  # -- URI used by clients to communicate with BindPlane.
   server_url: http://bindplane-op:3001
 
   # The URI used by OpAMP clients to communicate with bindplane-op. Defaults to the
   # clusterIP service. If you wish to communicate with bindplane-op through an ingress
   # service such as ingress-nginx, replace this value with the protocol (ws / wss), 
   # hostname, path, and port defined in your ingress rule.
+  # -- URI used by agents to communicate with BindPlane using OpAMP.
   remote_url: ws://bindplane-op:3001
 
   # kubectl -n <namesapce> create secret generic <name> \
@@ -102,14 +121,19 @@ config:
   #   --from-literal=password=mypassword \
   #   --from-literal=secret_key=353753ca-ae48-40f9-9588-28cf86430910 \
   #   --from-literal=sessions_secret=d9425db6-c4ee-4769-9c1f-a66987679e90
+  # -- Name of the Kubernetes secret which contains the `username`, `password`, `secret_key`, and `sessions_secret` configuration options.
   secret: bindplane
 
   # The following options override values set in the secret. Useful
   # for quick testing where you do not want to be bothered with managing
   # sensative values outside of helm.
+  # -- Username to use. Overrides `config.secret`.
   username: ""
+  # -- Password to use. Overrides `config.secret`.
   password: ""
+  # -- Secret Key to use. Overrides `config.secret`.
   secret_key: ""
+  # -- Sessions Secret to use. Overrides `config.secret`.
   sessions_secret: ""
 
 
@@ -119,16 +143,22 @@ config:
 # https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/
 resources:
   requests:
+    # -- Memory request.
     memory: 250Mi
+    # -- CPU request.
     cpu: 250m
   limits:
+    # -- Memory limit.
     memory: 500Mi
     # Disable cpu limit by default, for burstable qos class
     # cpu: 500m
 
 ingress:
+  # -- Whether or not to enable ingress.
   enable: false
   # ingress.host is required when `ingress.enable` is true. This should
   # be a fully qualified hostname.
+  # -- Hostname to use when ingress is enabled.
   host:
+  # -- Ingress class to use when ingress is enabled.
   class:

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -40,7 +40,8 @@ eventbus:
 auth:
   # Supported options:
   # - system (basic auth)
-  # - ldap (openldap, active directory, etc)
+  # - ldap
+  # - active-directory
   # 'system' will use the username and password specified
   # in config.secret or config.username / config.password.
   type: system
@@ -56,7 +57,10 @@ auth:
     # Example: cn=admin,dc=stage,dc=net
     bindUser: ""
     bindPassword: ""
-    searchFilter: (uid=%s)
+    # default values
+    # - ldap: (uid=%s)
+    # - active-directory: (|(sAMAccountName=%[1]v)(userPrincipalName=%[1]v))
+    searchFilter: ""
     tls:
       # Set to true to skip verification of the ldap server's certificate
       insecure: false


### PR DESCRIPTION
Added support for Enterprise ldap auth.

- Added environment configuration for basic ldap options (server, port, bind dn / user, etc)
- Added optional tls
  - Optional tls verification skipping
  - Optional tls ca certificate via secret volume mount

Tested the following scenarios
- `authType`: `system` (basic auth works here)
- `authType`: `ldap` (with tls disabled, ldap w/ port 1389)
- `authType`: `ldap` (with tls enabled, ldaps w/ port 1636)
  - tested with insecure true / false
  - tested with and without ca certificate secret

Example values used

```yaml
enterprise: true
backend:
  type: postgres
  postgres:
    host: postgres
    username: root
    password: password
    database: bindplane
eventbus:
  type: "" # pubsub
  pubsub:
    projectid: bpcli-dev
    topic: iris-updates
config:
  username: admin
  password: admin
  secret_key: <redacted>
  sessions_secret: <redacted>
image:
  # an image built from our beta branch of enterprise
  repository: <redacted>
  tag: <redacted>
auth:
  type: ldap
  # development openldap env
  ldap:
    protocol: ldaps
    server: openldap.openldap.svc.cluster.local
    port: 1636
    baseDN: ou=users,dc=stage,dc=net
    bindUser: cn=admin,dc=stage,dc=net
    bindPassword: stageadmin
    searchFilter: (uid=%s)
    tls:
      insecure: true
      ca:
        secret: openldap-tls
        subPath: ca.crt
```