### PR TITLE
feat: Tracing and documentation refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,98 @@
 
 # BindPlane OP Helm
 
-This repository contains a Helm chart developing [BindPlane OP](https://github.com/observIQ/bindplane-op).
+This repository contains a Helm chart for [BindPlane OP](https://github.com/observIQ/bindplane-op).
 
-## Usage
+## Prerequisites
 
-### Install Helm
+### Helm
 
 [Helm](https://helm.sh) must be installed to use the charts. Please refer to
 Helm's [documentation](https://helm.sh/docs) to get started.
 
-### Deploy BindPlane
+### Secrets
 
-See the [Chart documentation](./charts/bindplane/README.md) for deployment
-instructions.
+The Chart can accept a secret for configuring sensative options. This secret should be managed outside of helm with your preferred secret management solution. Alternatively, you can specify
+these options using a values file. See the [Chart documentation](./charts/bindplane/README.md).
+
+The secret should have the following keys:
+- `username`: Basic auth username to use for the default admin user
+- `password`: Basic auth password to use for the default admin user
+- `secret_key`: Random UUIDv4 to use for authenticating OpAMP clients
+- `sessions_secret`: Random UUIDv4 used to derive web interface session tokens
+
+Example: Create secret with `kubectl`:
+
+```shell
+kubectl -n default create secret generic bindplane \
+  --from-literal=username=myuser \
+  --from-literal=password=mypassword \
+  --from-literal=secret_key=353753ca-ae48-40f9-9588-28cf86430910 \
+  --from-literal=sessions_secret=d9425db6-c4ee-4769-9c1f-a66987679e90
+```
+
+## Configuration
+
+See the [Chart documentation](./charts/bindplane/README.md) for configuration documentation.
+
+## Usage
+
+Add the repository:
+
+```bash
+helm repo add bindplane \
+    https://observiq.github.io/bindplane-op-helm
+
+helm repo update
+helm search repo
+```
+
+Install
+
+```bash
+helm upgrade --install bindplane bindplane/bindplane
+```
+
+## Connectivity
+
+BindPlane can be reached using the clusterIP service deployed by the chart. By default the service
+name is `bindplane` and the port is `3001`.
+
+**Web Interface**
+
+You can connect to BindPlane from your workstation using port forwarding:
+
+```bash
+kubectl -n default port-forward svc/bindplane 3001
+```
+
+You should now be able to access http://localhost:3001
+
+**Command Line**
+
+You can connect to BindPlane from your workstation using port forwarding:
+
+```bash
+kubectl -n default port-forward svc/bindplane 3001
+```
+
+Create and use a profile:
+
+```bash
+bindplanectl profile set myprofile \
+  --username <username> \
+  --password <password> \
+  --server-url http://localhost:3001
+
+bindplanectl profile use myprofile
+```
+
+You should be able to issue commands: `bindplanectl get agent`
+
+**Collectors**
+
+Collectors running within the cluster can connect with the following OpAMP URI:
+
+```
+ws://bindplane.default.svc.cluster.local:3001/v1/opamp
+```

--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an open source observability pipeline.
 type: application
 # The chart's version
-version: 0.0.10
+version: 0.0.11
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.8.0

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,102 +1,68 @@
-# BindPlane OP Chart
+# bindplane
 
-## Installing the Chart
+![Version: 0.0.11](https://img.shields.io/badge/Version-0.0.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
 
-### Add Repo
+BindPlane OP is an open source observability pipeline.
 
-```bash
-helm repo add bindplane \
-    https://observiq.github.io/bindplane-op-helm
+**Homepage:** <https://github.com/observIQ/bindplane-op>
 
-helm repo update
-helm search repo
-```
+## Maintainers
 
-### Create Secret
+| Name | Email | Url |
+| ---- | ------ | --- |
+| jsirianni | <joe.sirianni@observiq.com> |  |
 
-BindPlane OP requires a secret for configuring sensative options. This secret should be managed outside of helm with your preferred secret management solution.
+## Source Code
 
-The secret should have the following keys:
-- `username`: Basic auth username to use for the default admin user
-- `password`: Basic auth password to use for the default admin user
-- `secret_key`: Random UUIDv4 to use for authenticating OpAMP clients
-- `sessions_secret`: Random UUIDv4 used to derive web interface session tokens
+* <https://github.com/observIQ/bindplane-op/>
 
-Example: Create secret with `kubectl`:
+## Values
 
-```shell
-kubectl -n default create secret generic bindplane \
-  --from-literal=username=myuser \
-  --from-literal=password=mypassword \
-  --from-literal=secret_key=353753ca-ae48-40f9-9588-28cf86430910 \
-  --from-literal=sessions_secret=d9425db6-c4ee-4769-9c1f-a66987679e90
-```
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| auth.ldap | object | `{"baseDN":"","bindPassword":"","bindUser":"","port":null,"protocol":"ldap","searchFilter":"","server":"","tls":{"ca":{"secret":"","subPath":""},"insecure":false}}` | Configuration options for 'ldap' and 'active-directory' authentication backends. |
+| auth.ldap.baseDN | string | `""` | Base DN to use when looking up users. Example: `ou=users,dc=stage,dc=net`. |
+| auth.ldap.bindPassword | string | `""` | Password to use for the bind user. |
+| auth.ldap.bindUser | string | `""` | User to use when looking up users. Example: `cn=admin,dc=stage,dc=net.` |
+| auth.ldap.port | string | `nil` | TCP port to use when connecting to the ldap server. Defaults to `1389` (plain text) or `1636` (tls). |
+| auth.ldap.protocol | string | `"ldap"` | Protocol to use. Available options include `ldap` (plain text) and `ldaps` (tls). |
+| auth.ldap.searchFilter | string | `""` | Search filter to use when looking up users. Defaults to `(uid=%s)` (ldap) and `(|(sAMAccountName=%[1]v)(userPrincipalName=%[1]v))` (active-directory). |
+| auth.ldap.server | string | `""` | Hostname or IP address of the ldap server. |
+| auth.ldap.tls.ca.secret | string | `""` | Name of the Kubernetes secret which contains the ldap server's certificate authority public certificate. |
+| auth.ldap.tls.ca.subPath | string | `""` | The secret's subPath which contains the certificate. |
+| auth.ldap.tls.insecure | bool | `false` | Whether or not to skip verification of the ldap server's certificate. |
+| auth.type | string | `"system"` | Backend to use for authentication. Available options include `system`, `ldap` (Enterprise) and `active-directory` (Enterprise). |
+| backend.bbolt.volumeSize | string | `"10Gi"` | Persistent volume size. |
+| backend.postgres.database | string | `""` | Database to use. |
+| backend.postgres.host | string | `"localhost"` | Hostname or IP address of the Postgres server. |
+| backend.postgres.maxConnections | int | `100` | Max number of connections to use when communicating with Postgres. |
+| backend.postgres.password | string | `""` | Password for the username used to connect to Postgres. |
+| backend.postgres.port | int | `5432` | TCP port used to connect to Postgres. |
+| backend.postgres.sslmode | string | `"disable"` | SSL mode to use when connecting to Postgres over TLS. See the [postgres ssl documentation](https://jdbc.postgresql.org/documentation/ssl/) for valid options. |
+| backend.postgres.username | string | `""` | Username to use when connecting to Postgres. |
+| backend.type | string | `"bbolt"` | Backend to use for persistent storage. Available options are `bbolt`, and `postgres` (Enterprise). |
+| config.password | string | `""` | Password to use. Overrides `config.secret`. |
+| config.remote_url | string | `"ws://bindplane-op:3001"` | URI used by agents to communicate with BindPlane using OpAMP. |
+| config.secret | string | `"bindplane"` | Name of the Kubernetes secret which contains the `username`, `password`, `secret_key`, and `sessions_secret` configuration options. |
+| config.secret_key | string | `""` | Secret Key to use. Overrides `config.secret`. |
+| config.server_url | string | `"http://bindplane-op:3001"` | URI used by clients to communicate with BindPlane. |
+| config.sessions_secret | string | `""` | Sessions Secret to use. Overrides `config.secret`. |
+| config.username | string | `""` | Username to use. Overrides `config.secret`. |
+| enterprise | bool | `false` | Whether or not enterprise edition is enabled. Enterprise users require a valid Enterprise subscription. |
+| eventbus.pubsub.credentials.secret | string | `""` | Optional Kubernetes secret which contains Google Cloud JSON service account credentials. Not required when running within Google Cloud with the Pub/Sub scope enabled. |
+| eventbus.pubsub.credentials.subPath | string | `""` | Sub path for the secret which contains the Google Cloud credential JSON |
+| eventbus.pubsub.projectid | string | `""` |  |
+| eventbus.pubsub.topic | string | `""` |  |
+| eventbus.type | string | `""` |  |
+| image.repository | string | `"ghcr.io/observiq/bindplane"` | Repository and image to use. |
+| image.tag | string | `""` | Image tag to use. Defaults to the version defined in the Chart's release. |
+| ingress.class | string | `nil` | Ingress class to use when ingress is enabled. |
+| ingress.enable | bool | `false` | Whether or not to enable ingress. |
+| ingress.host | string | `nil` | Hostname to use when ingress is enabled. |
+| resources.limits.memory | string | `"500Mi"` | Memory limit. |
+| resources.requests.cpu | string | `"250m"` | CPU request. |
+| resources.requests.memory | string | `"250Mi"` | Memory request. |
+| trace.otlp.endpoint | string | `""` | "Endpoint of the OTLP trace receiver. Should be in the form of ip:port or host:port." |
+| trace.otlp.insecure | bool | `false` | "Set to `true` to disable TLS. Set to false if TLS is in use by the OTLP trace receiver." |
+| trace.type | string | `""` | Trace type to use. Valid options include `otlp`. |
 
-### Install Chart
-
-```bash
-helm upgrade --install bindplane bindplane/bindplane
-```
-
-## Configuration
-
-The following table lists the configurable parameters of the BindPlaneOP chart.                                                                                                                                                   
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `backend.type` | Backend to use for persistent storage. When set to `bbolt`, bindplane will be deployed as a single pod StatefulSet using a persistent volume. | `bbolt` |
-| `backend.bbolt.volumeSize` | Persistent volume size. | `10Gi` |
-| `image.repository` | Container repository to use. | `observiq/bindplane` |
-| `image.tag`        | Image tag to use. | Derived from chart version. |
-| `config.server_url` | The URI used by clients to communicate with bindplane-op's REST API. | `http://bindplane-op:3001` |
-| `config.remote_url` | The URI used by clients to communicate with bindplane-op's OpAMP interface. | `ws://bindplane-op:3001` |
-| `config.secret`     | See the [create secret](#create-secret) section. | `bindplane` |
-| `resources.requests.cpu`    | [Requested CPU](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) | `250m` |
-| `resources.requests.memory` | [Requested Memory](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) | `250Mi` |
-| `resources.limits.cpu`      | [CPU limit](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) | Not set (burstable qos) |
-| `resources.memory.cpu`      | [Memory limit](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) | `500Mi` |
-
-Detailed documentation for BindPlane OP's configuration can be found [here](../../docs/configuration.md)
-
-## Connectivity
-
-BindPlane can be reached using the clusterIP service deployed by the chart. By default the service
-name is `bindplane` and the port is `3001`.
-
-**Web Interface**
-
-You can connect to BindPlane from your workstation using port forwarding:
-
-```bash
-kubectl -n default port-forward svc/bindplane 3001
-```
-
-You should now be able to access http://localhost:3001
-
-**Command Line**
-
-You can connect to BindPlane from your workstation using port forwarding:
-
-```bash
-kubectl -n default port-forward svc/bindplane 3001
-```
-
-Create and use a profile:
-
-```bash
-bindplanectl profile set myprofile \
-  --username <username> \
-  --password <password> \
-  --server-url http://localhost:3001
-
-bindplanectl profile use myprofile
-```
-
-You should be able to issue commands: `bindplanectl get agent`
-
-**Collectors**
-
-Collectors running within the cluster can connect with the following OpAMP URI:
-
-```
-ws://bindplane.default.svc.cluster.local:3001/v1/opamp
-```

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -20,7 +20,6 @@ BindPlane OP is an open source observability pipeline.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| auth.ldap | object | `{"baseDN":"","bindPassword":"","bindUser":"","port":null,"protocol":"ldap","searchFilter":"","server":"","tls":{"ca":{"secret":"","subPath":""},"insecure":false}}` | Configuration options for 'ldap' and 'active-directory' authentication backends. |
 | auth.ldap.baseDN | string | `""` | Base DN to use when looking up users. Example: `ou=users,dc=stage,dc=net`. |
 | auth.ldap.bindPassword | string | `""` | Password to use for the bind user. |
 | auth.ldap.bindUser | string | `""` | User to use when looking up users. Example: `cn=admin,dc=stage,dc=net.` |

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -85,6 +85,14 @@ spec:
                   key: sessions_secreet
                   optional: true
               {{- end }}
+            {{- if .Values.trace.type }}
+            - name: BINDPLANE_CONFIG_TRACE_TYPE
+              value: {{ .Values.trace.type }}
+            - name: BINDPLANE_CONFIG_OTLP_TRACING_ENDPOINT
+              value: {{ .Values.trace.otlp.endpoint }}
+            - name: BINDPLANE_CONFIG_OTLP_TRACING_INSECURE_TLS
+              value: "{{ .Values.trace.otlp.insecure }}"
+            {{- end }}
             - name: BINDPLANE_CONFIG_LOG_OUTPUT
               value: stdout
             - name: BINDPLANE_CONFIG_HOME

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -162,3 +162,13 @@ ingress:
   host:
   # -- Ingress class to use when ingress is enabled.
   class:
+
+trace:
+  # -- Trace type to use. Valid options include `otlp`.
+  type: ""
+
+  otlp:
+    # -- "Endpoint of the OTLP trace receiver. Should be in the form of ip:port or host:port."
+    endpoint: ""
+    # -- "Set to `true` to disable TLS. Set to false if TLS is in use by the OTLP trace receiver."
+    insecure: false

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -58,7 +58,6 @@ auth:
   # -- Backend to use for authentication. Available options include `system`, `ldap` (Enterprise) and `active-directory` (Enterprise).
   type: system
 
-  # -- Configuration options for 'ldap' and 'active-directory' authentication backends.
   ldap:
     # -- Protocol to use. Available options include `ldap` (plain text) and `ldaps` (tls).
     protocol: ldap

--- a/doc/developing.md
+++ b/doc/developing.md
@@ -1,0 +1,16 @@
+# Developing
+
+## Tools
+
+- [Helm](https://helm.sh/docs/helm/helm_install/)
+- [helm-docs](https://github.com/norwoodj/helm-docs)
+
+## Generate Documentation
+
+Configuraton options are generated using [helm-docs](https://github.com/norwoodj/helm-docs).
+
+To re-generate `charts/bindplane/README.md`, simply run:
+
+```bash
+helm-docs
+```


### PR DESCRIPTION
- Added options for enabling OTLP tracing.
- Merged charts/bindplane/README.md into the main README
- Used [helm-docs](https://github.com/norwoodj/helm-docs) to generate configuration documentation at charts/bindplane/README.md

Tested against my own collector with OTLP receiver.

```yaml
# Values config
...
trace:
  type: otlp
  otlp:
    # my otlp collector
    endpoint: 10.99.1.10:4317
    insecure: true
...
```
```
# kubectl get sts bindplane -o yaml
...
        - name: BINDPLANE_CONFIG_TRACE_TYPE
          value: otlp
        - name: BINDPLANE_CONFIG_OTLP_TRACING_ENDPOINT
          value: 10.99.1.10:4317
        - name: BINDPLANE_CONFIG_OTLP_TRACING_INSECURE_TLS
          value: "true"
...
```

![Screenshot from 2023-02-17 10-48-52](https://user-images.githubusercontent.com/23043836/219701180-39218185-d19c-4699-8b3b-84d720ec81ae.png)

![Screenshot from 2023-02-17 10-51-03](https://user-images.githubusercontent.com/23043836/219701311-e789b8e5-a4fa-4b38-842f-743825da78db.png)
