### PR TITLE
feat: Support Enterprise multi account

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an open source observability pipeline.
 type: application
 # The chart's version
-version: 0.0.11
+version: 0.0.12
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.8.0

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -58,6 +58,7 @@ BindPlane OP is an open source observability pipeline.
 | ingress.class | string | `nil` | Ingress class to use when ingress is enabled. |
 | ingress.enable | bool | `false` | Whether or not to enable ingress. |
 | ingress.host | string | `nil` | Hostname to use when ingress is enabled. |
+| multiAccount | bool | `false` | Whether or not multi account support is enabled (Enterprise). |
 | resources.limits.memory | string | `"500Mi"` | Memory limit. |
 | resources.requests.cpu | string | `"250m"` | CPU request. |
 | resources.requests.memory | string | `"250Mi"` | Memory request. |

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -164,6 +164,10 @@ spec:
               value: "true"
             {{- end }}
             {{- end }}
+            {{- if and (eq .Values.enterprise true) (eq .Values.multiAccount true) }}
+            - name: BINDPLANE_CONFIG_ENABLE_ACCOUNTS
+              value: "true"
+            {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -1,6 +1,9 @@
 # -- Whether or not enterprise edition is enabled. Enterprise users require a valid Enterprise subscription.
 enterprise: false
 
+# -- Whether or not multi account support is enabled (Enterprise).
+multiAccount: false
+
 backend:
   # -- Backend to use for persistent storage. Available options are `bbolt`, and `postgres` (Enterprise).
   type: bbolt


### PR DESCRIPTION
The environment variable `BINDPLANE_CONFIG_ENABLE_ACCOUNTS` enables or disables multi account when running Enterprise versions of BindPlane OP.

When `enterprise` and `multiAccount` are `true`, I get the following (multi account at the bottom):

```yaml
...          env:
            - name: BINDPLANE_CONFIG_SERVER_URL
              value: http://bindplane-op:3001
            - name: BINDPLANE_CONFIG_REMOTE_URL
              value: ws://bindplane-op:3001
            - name: BINDPLANE_CONFIG_USERNAME
              value: admin
            - name: BINDPLANE_CONFIG_PASSWORD
              value: admin
            - name: BINDPLANE_CONFIG_SECRET_KEY
              value: 5610d41e-1096-4867-b062-2c063bc45553
            - name: BINDPLANE_CONFIG_SESSIONS_SECRET
              value: 9b48f890-2c85-4e8f-98c1-2b6cfc9da8f0
            - name: BINDPLANE_CONFIG_LOG_OUTPUT
              value: stdout
            - name: BINDPLANE_CONFIG_HOME
              value: /data
            - name: BINDPLANE_CONFIG_STORE_TYPE
              value: bbolt
            - name: BINDPLANE_CONFIG_STORAGE_FILE_PATH
              value: /data/storage
            - name: BINDPLANE_CONFIG_ENABLE_ACCOUNTS
              value: "true"
...
```

When `enterprise` or `multiAccount` are disabled, the `BINDPLANE_CONFIG_ENABLE_ACCOUNTS` option is correctly omitted.