### PR TITLE
Refactor image name and tag handling

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an open source observability pipeline.
 type: application
 # The chart's version
-version: 0.0.12
+version: 0.0.13
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.8.0

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 0.0.12](https://img.shields.io/badge/Version-0.0.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
+![Version: 0.0.13](https://img.shields.io/badge/Version-0.0.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
 
 BindPlane OP is an open source observability pipeline.
 

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 0.0.11](https://img.shields.io/badge/Version-0.0.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
+![Version: 0.0.12](https://img.shields.io/badge/Version-0.0.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
 
 BindPlane OP is an open source observability pipeline.
 
@@ -53,7 +53,7 @@ BindPlane OP is an open source observability pipeline.
 | eventbus.pubsub.projectid | string | `""` |  |
 | eventbus.pubsub.topic | string | `""` |  |
 | eventbus.type | string | `""` |  |
-| image.repository | string | `"ghcr.io/observiq/bindplane"` | Repository and image to use. |
+| image.name | string | `""` | Image name to be used. Defaults to `ghcr.io/observiq/bindplane` and `ghcr.io/observiq/bindplane-ee` for Enterprise deployments. |
 | image.tag | string | `""` | Image tag to use. Defaults to the version defined in the Chart's release. |
 | ingress.class | string | `nil` | Ingress class to use when ingress is enabled. |
 | ingress.enable | bool | `false` | Whether or not to enable ingress. |

--- a/charts/bindplane/templates/_helpers.tpl
+++ b/charts/bindplane/templates/_helpers.tpl
@@ -29,10 +29,17 @@ The image to use
 */}}
 {{- define "bindplane.image" -}}
 {{- if eq .Values.enterprise true -}}
-{{- printf "%s:%s" (default (printf "ghcr.io/observiq/bindplane-ee") .Values.image.name) (default (printf "%s" .Chart.AppVersion) .Values.image.tag) }}
+{{- printf "%s" (default (printf "ghcr.io/observiq/bindplane-ee") .Values.image.name) }}
 {{- else -}}
-{{- printf "%s:%s" (default (printf "ghcr.io/observiq/bindplane") .Values.image.name) (default (printf "%s" .Chart.AppVersion) .Values.image.tag) }}
+{{- printf "%s" (default (printf "ghcr.io/observiq/bindplane") .Values.image.name) }}
 {{- end -}}
+{{- end -}}
+
+{{/*
+The image tag to use
+*/}}
+{{- define "bindplane.tag" -}}
+{{- printf "%s" (default (printf "%s" .Chart.AppVersion) .Values.image.tag) }}
 {{- end -}}
 
 {{/*

--- a/charts/bindplane/templates/_helpers.tpl
+++ b/charts/bindplane/templates/_helpers.tpl
@@ -29,9 +29,9 @@ The image to use
 */}}
 {{- define "bindplane.image" -}}
 {{- if eq .Values.enterprise true -}}
-{{- printf "%s-ee:%s" .Values.image.repository (default (printf "%s" .Chart.AppVersion) .Values.image.tag) }}
+{{- printf "%s:%s" (default (printf "ghcr.io/observiq/bindplane-ee") .Values.image.name) (default (printf "%s" .Chart.AppVersion) .Values.image.tag) }}
 {{- else -}}
-{{- printf "%s:%s" .Values.image.repository (default (printf "%s" .Chart.AppVersion) .Values.image.tag) }}
+{{- printf "%s:%s" (default (printf "ghcr.io/observiq/bindplane") .Values.image.name) (default (printf "%s" .Chart.AppVersion) .Values.image.tag) }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -35,13 +35,7 @@ spec:
         fsGroup: 65534
       containers:
         - name: server
-          {{- if .Values.image.name }}
-          image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
-          {{- else if eq .Values.enterprise true }}
-          image: "ghcr.io/observiq/bindplane:{{ .Values.image.tag }}"
-          {{- else }}
-          image: "ghcr.io/observiq/bindplane-ee:{{ .Values.image.tag }}"
-          {{- end }}
+          image: {{ include "bindplane.image" . }}:{{ include "bindplane.tag" . }}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3001

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -35,7 +35,13 @@ spec:
         fsGroup: 65534
       containers:
         - name: server
-          image: {{ include "bindplane.image" . }}
+          {{- if .Values.image.name }}
+          image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
+          {{- else if eq .Values.enterprise true }}
+          image: "ghcr.io/observiq/bindplane:{{ .Values.image.tag }}"
+          {{- else }}
+          image: "ghcr.io/observiq/bindplane-ee:{{ .Values.image.tag }}"
+          {{- end }}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3001

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -93,10 +93,8 @@ auth:
         subPath: ""
 
 image:
-  # TODO(jsirianni): break repository into 'repository' and 'image'
-  # or rename repository to image.
-  # -- Repository and image to use.
-  repository: ghcr.io/observiq/bindplane
+  # -- Image name to be used. Defaults to `ghcr.io/observiq/bindplane` and `ghcr.io/observiq/bindplane-ee` for Enterprise deployments.
+  name: ""
   # Overrides the image tag whose default is {{ .Chart.AppVersion }}
   # -- Image tag to use. Defaults to the version defined in the Chart's release.
   tag: ""


### PR DESCRIPTION
Image name handling is somewhat clunky right now because we insert `-ee` into `image.repository` if `enterprise: true`. This is annoying when you are setting `image.repository` yourself, because you get an unpredictable output.

This PR refactors image handling by avoiding the `-ee` insertion if the user has set their own repository (new `image.name` option).

- Replaced `image.repository` with more appropriate `image.name` parameter
- Refactored the image.repository helper to handle default `image.name` values based on whether enterprise is enabled or not. This behavior is ignored if the user has specified their own image.name.
- Moved image tag handling to its own helper.

Tested the following value options:

```yaml
# outputs ghcr.io/observiq/bindplane:1.8.0
enterprise: false
```
```yaml
# outputs ghcr.io/observiq/bindplane-ee:abcd
enterprise: true
image:
  tag: abcd
```
```yaml
# outputs ghcr.io/observiq/bindplane-ee:1.8.0
enterprise: true
```
```yaml
# outputs ghcr.io/observiq/bindplane:abcd
enterprise: false
image:
  tag: abcd
```
```yaml
# outputs bmedora/bindplane:fancytag
image:
  name: bmedora/bindplane
  tag: fancytag
```