### PR TITLE
feat: Add HPA config

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an open source observability pipeline.
 type: application
 # The chart's version
-version: 0.0.13
+version: 0.0.14
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.8.0

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 0.0.13](https://img.shields.io/badge/Version-0.0.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
+![Version: 0.0.14](https://img.shields.io/badge/Version-0.0.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
 
 BindPlane OP is an open source observability pipeline.
 
@@ -31,6 +31,11 @@ BindPlane OP is an open source observability pipeline.
 | auth.ldap.tls.ca.subPath | string | `""` | The secret's subPath which contains the certificate. |
 | auth.ldap.tls.insecure | bool | `false` | Whether or not to skip verification of the ldap server's certificate. |
 | auth.type | string | `"system"` | Backend to use for authentication. Available options include `system`, `ldap` (Enterprise) and `active-directory` (Enterprise). |
+| autoscaling.enable | bool | `false` |  |
+| autoscaling.max | int | `10` |  |
+| autoscaling.min | int | `2` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `60` |  |
+| autoscaling.targetMemoryUtilizationPercentage | int | `60` |  |
 | backend.bbolt.volumeSize | string | `"10Gi"` | Persistent volume size. |
 | backend.postgres.database | string | `""` | Database to use. |
 | backend.postgres.host | string | `"localhost"` | Hostname or IP address of the Postgres server. |

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -31,11 +31,11 @@ BindPlane OP is an open source observability pipeline.
 | auth.ldap.tls.ca.subPath | string | `""` | The secret's subPath which contains the certificate. |
 | auth.ldap.tls.insecure | bool | `false` | Whether or not to skip verification of the ldap server's certificate. |
 | auth.type | string | `"system"` | Backend to use for authentication. Available options include `system`, `ldap` (Enterprise) and `active-directory` (Enterprise). |
-| autoscaling.enable | bool | `false` |  |
-| autoscaling.max | int | `10` |  |
-| autoscaling.min | int | `2` |  |
-| autoscaling.targetCPUUtilizationPercentage | int | `60` |  |
-| autoscaling.targetMemoryUtilizationPercentage | int | `60` |  |
+| autoscaling.enable | bool | `false` | "Whether or not autoscaling should be enabled. Requires an eventbus to be configured." |
+| autoscaling.max | int | `10` | "Maximum number of pods when autoscaling is enabled." |
+| autoscaling.min | int | `2` | "Minimum number of pods when autoscaling is enabled." |
+| autoscaling.targetCPUUtilizationPercentage | int | `60` | "Autoscaling target CPU usage percentage." |
+| autoscaling.targetMemoryUtilizationPercentage | int | `60` | "Autoscaling target Memory usage percentage." |
 | backend.bbolt.volumeSize | string | `"10Gi"` | Persistent volume size. |
 | backend.postgres.database | string | `""` | Database to use. |
 | backend.postgres.host | string | `"localhost"` | Hostname or IP address of the Postgres server. |

--- a/charts/bindplane/templates/hpa.yaml
+++ b/charts/bindplane/templates/hpa.yaml
@@ -1,0 +1,30 @@
+{{- if and (eq .Values.autoscaling.enable true) (include "bindplane.deployment_type" .) "Deployment" }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "bindplane.fullname" . }}
+spec:
+  minReplicas: {{ .Values.autoscaling.min }}
+  maxReplicas: {{ .Values.autoscaling.max }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "bindplane.fullname" . }}
+  metrics:
+{{- with .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+{{- end }}
+{{- with .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+{{- end }}
+{{- end }}

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -174,8 +174,13 @@ trace:
     insecure: false
 
 autoscaling:
+  # -- "Whether or not autoscaling should be enabled. Requires an eventbus to be configured."
   enable: false
+  # -- "Minimum number of pods when autoscaling is enabled."
   min: 2
+  # -- "Maximum number of pods when autoscaling is enabled."
   max: 10
+  # -- "Autoscaling target CPU usage percentage."
   targetCPUUtilizationPercentage: 60
+  # -- "Autoscaling target Memory usage percentage."
   targetMemoryUtilizationPercentage: 60

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -172,3 +172,10 @@ trace:
     endpoint: ""
     # -- "Set to `true` to disable TLS. Set to false if TLS is in use by the OTLP trace receiver."
     insecure: false
+
+autoscaling:
+  enable: false
+  min: 2
+  max: 10
+  targetCPUUtilizationPercentage: 60
+  targetMemoryUtilizationPercentage: 60


### PR DESCRIPTION
Added HPA configuration when pubsub + deployment type are used.

The following options generate an HPA config:
```yaml
enterprise: true
eventbus:
  type: pubsub
  pubsub:
    projectid: bpcli-dev
    topic: test
backend:
  type: postgres
  postgres:
    database: bindplane
    username: postgres
    password: password
autoscaling:
  enable: true
```
```yaml
---
# Source: bindplane/templates/hpa.yaml
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  name: RELEASE-NAME-bindplane
spec:
  minReplicas: 2
  maxReplicas: 10
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: RELEASE-NAME-bindplane
  metrics:
    - type: Resource
      resource:
        name: memory
        target:
          type: Utilization
          averageUtilization: 60
    - type: Resource
      resource:
        name: cpu
        target:
          type: Utilization
          averageUtilization: 60
```