### PR TITLE
feat: Support email invitations w/ Sendgrid

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an open source observability pipeline.
 type: application
 # The chart's version
-version: 0.0.14
+version: 0.0.15
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.8.0

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 0.0.14](https://img.shields.io/badge/Version-0.0.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
+![Version: 0.0.15](https://img.shields.io/badge/Version-0.0.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
 
 BindPlane OP is an open source observability pipeline.
 
@@ -52,6 +52,8 @@ BindPlane OP is an open source observability pipeline.
 | config.server_url | string | `"http://bindplane-op:3001"` | URI used by clients to communicate with BindPlane. |
 | config.sessions_secret | string | `""` | Sessions Secret to use. Overrides `config.secret`. |
 | config.username | string | `""` | Username to use. Overrides `config.secret`. |
+| email.sendgrid.token | string | `""` | The sendgrid API token to use when authenticating to Sendgrid. |
+| email.type | string | `""` | The optional email backend type to use (Enterprise). Valid options include `sendgrid`. Requires an auth type other than `system`. |
 | enterprise | bool | `false` | Whether or not enterprise edition is enabled. Enterprise users require a valid Enterprise subscription. |
 | eventbus.pubsub.credentials.secret | string | `""` | Optional Kubernetes secret which contains Google Cloud JSON service account credentials. Not required when running within Google Cloud with the Pub/Sub scope enabled. |
 | eventbus.pubsub.credentials.subPath | string | `""` | Sub path for the secret which contains the Google Cloud credential JSON |

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -168,7 +168,7 @@ spec:
             - name: BINDPLANE_CONFIG_ENABLE_ACCOUNTS
               value: "true"
             {{- end }}
-            {{- if and (eq .Values.email.type "sendgrid") (eq .Values.multiAccount true) }}
+            {{- if and (eq .Values.email.type "sendgrid") (eq .Values.multiAccount true) (ne .Values.auth.type "system") }}
             - name: BINDPLANE_CONFIG_SENDGRID_API_TOKEN
               value: {{ .Values.email.sendgrid.token }}
             {{- end }}

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -168,6 +168,10 @@ spec:
             - name: BINDPLANE_CONFIG_ENABLE_ACCOUNTS
               value: "true"
             {{- end }}
+            {{- if and (eq .Values.email.type "sendgrid") (eq .Values.multiAccount true) }}
+            - name: BINDPLANE_CONFIG_SENDGRID_API_TOKEN
+              value: {{ .Values.email.sendgrid.token }}
+            {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -184,3 +184,10 @@ autoscaling:
   targetCPUUtilizationPercentage: 60
   # -- "Autoscaling target Memory usage percentage."
   targetMemoryUtilizationPercentage: 60
+
+email:
+  # -- The optional email backend type to use (Enterprise). Valid options include `sendgrid`. Requires an auth type other than `system`.
+  type: ""
+  sendgrid:
+    # -- The sendgrid API token to use when authenticating to Sendgrid.
+    token: ""


### PR DESCRIPTION
TODO
- merge https://github.com/observIQ/bindplane-op-helm/pull/12 and rebase
- bump chart version
- regen chart values doc with `helm-docs`

Added email configuration with sendgrid with support for other backends in the future.

I deployed to a GKE cluster using postgres, pubsub, and openldap. When multi account is enabled, the email option is functional in the UI.