### PR TITLE
fix(hpa): Do not set replicas unless running as statefulset

### DIFF
--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -13,8 +13,6 @@ spec:
   {{- if eq (include "bindplane.deployment_type" .) "StatefulSet" }}
   replicas: 1
   serviceName: {{ include "bindplane.fullname" . }}
-  {{- else }}
-  replicas: 1
   {{- end }}
   selector:
     matchLabels:


### PR DESCRIPTION
When using an HPA, we want to avoid specifying the replicas in the deployment spec. The HPA will handle determining the correct replica count. If replicas are set in the deployment, the deployment will scale down during a rolling update.

If HPA is not in use, the deployment will default to one replica anyway.

Helm template shows one replica when statefulset is used and no replicas when deployment is used.

Statefulset:
```yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: release-name-bindplane
  namespace: default
  labels:
    app.kubernetes.io/name: bindplane
    app.kubernetes.io/stack: bindplane
    app.kubernetes.io/component: server
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
  ...
```

Deployment:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-bindplane
  namespace: default
  labels:
    app.kubernetes.io/name: bindplane
    app.kubernetes.io/stack: bindplane
    app.kubernetes.io/component: server
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
spec:
  selector:
  ...
```