### PR TITLE
fix: Default values for config.server_url and config.remote_url

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an open source observability pipeline.
 type: application
 # The chart's version
-version: 0.0.21
+version: 0.0.22
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.12.2

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -40,9 +40,17 @@ spec:
               name: http
           env:
             - name: BINDPLANE_CONFIG_SERVER_URL
+              {{- if .Values.config.server_url }}
               value: {{ .Values.config.server_url }}
+              {{- else }}
+              value: http://{{ include "bindplane.fullname" . }}:3001
+              {{- end }}
             - name: BINDPLANE_CONFIG_REMOTE_URL
+              {{- if .Values.config.remote_url }}
               value: {{ .Values.config.remote_url }}
+              {{- else }}
+              value: ws://{{ include "bindplane.fullname" . }}:3001
+              {{- end }}
             - name: BINDPLANE_CONFIG_USERNAME
               {{- if  .Values.config.username }}
               value: {{ .Values.config.username }}

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -111,14 +111,14 @@ config:
   # service such as ingress-nginx, replace this value with the protocol (http / https), 
   # hostname, path, and port defined in your ingress rule.
   # -- URI used by clients to communicate with BindPlane.
-  server_url: http://bindplane-op:3001
+  server_url: ""
 
   # The URI used by OpAMP clients to communicate with bindplane-op. Defaults to the
   # clusterIP service. If you wish to communicate with bindplane-op through an ingress
   # service such as ingress-nginx, replace this value with the protocol (ws / wss), 
   # hostname, path, and port defined in your ingress rule.
   # -- URI used by agents to communicate with BindPlane using OpAMP.
-  remote_url: ws://bindplane-op:3001
+  remote_url: ""
 
   # kubectl -n <namesapce> create secret generic <name> \
   #   --from-literal=username=myuser \


### PR DESCRIPTION
Instead of defaulting to "bindplane" for server_url and remote_url, we should be using the helm deployment name (by default) and only using config.server_url / config.remote_url if the user deliberately species them in their values file.

This PR does the following
- removes default values for server_url and remote_url from values.yaml
- if server_url / remote_url are not set, derive the values from the deployment name
- if server_url  /remote_url are set, use them directly

With this method, the default server_url and remote_url will match the clusterIP service name. Users can set their own options which are more appropriate for their environment, like when running behind an ingress service + load balancer.

This change is backwards compatible. 

Deploying the chart with default values gives us a service name of `release-name-bindplane` and the following env:
```
      - name: BINDPLANE_CONFIG_SERVER_URL
        value: http://release-name-bindplane:3001
      - name: BINDPLANE_CONFIG_REMOTE_URL
        value: ws://release-name-bindplane:3001
```

Deploying the chart with default values and the name `bindplane` gives us a service name of `bindplane` and the following env:
```
      - name: BINDPLANE_CONFIG_SERVER_URL
        value: http://bindplane:3001
      - name: BINDPLANE_CONFIG_REMOTE_URL
        value: ws://bindplane:3001
```

Deploying the chart with default values and the name `my-bindplane` gives us a service name of `my-bindplane` and the following env:
```
      - name: BINDPLANE_CONFIG_SERVER_URL
        value: http://my-bindplane:3001
      - name: BINDPLANE_CONFIG_REMOTE_URL
        value: ws://my-bindplane:3001
```

A values.yaml with server_url and remote_url set results in the env being overrideen with these values, instead of being
set to the service name.
```yaml
config:
  server_url: http://bindplane.local:3001
  remote_url: ws://bindplane.local:3001
```
```
      - name: BINDPLANE_CONFIG_SERVER_URL
        value: http://bindplane.local:3001
      - name: BINDPLANE_CONFIG_REMOTE_URL
        value: ws://bindplane.local:3001
```

