### PR TITLE
Set proxy read timeout

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an open source observability pipeline.
 type: application
 # The chart's version
-version: 0.0.22
+version: 0.0.23
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.12.2

--- a/charts/bindplane/templates/ingress.yml
+++ b/charts/bindplane/templates/ingress.yml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     {{- if .Values.ingress.class }}
     kubernetes.io/ingress.class: {{ .Values.ingress.class }}
     {{- end }}

--- a/charts/bindplane/templates/ingress.yml
+++ b/charts/bindplane/templates/ingress.yml
@@ -10,9 +10,11 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     {{- if .Values.ingress.class }}
     kubernetes.io/ingress.class: {{ .Values.ingress.class }}
+    {{- if eq .Values.ingress.class "nginx" }}
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    {{- end }}
     {{- end }}
     {{- if .Values.ingress.annotations }}
     {{ toYaml .Values.ingress.annotations }}

--- a/test/cases/ingress/values.yaml
+++ b/test/cases/ingress/values.yaml
@@ -4,6 +4,8 @@ config:
   password: bppass
   secret_key: 12D8FB6E-1532-4A4C-97AF-95A430BE5E6E
   sessions_secret: 4484766F-5016-4077-B8E0-0DE1D637854B
+  server_url: http://bindplane.local:80
+  remote_url: ws://bindplane.local:80
 
 # Ingress
 ingress:


### PR DESCRIPTION
When using ingress

Setting `nginx.ingress.kubernetes.io/proxy-read-timeout` to 1 hour (from 60 seconds) will prevent collector opamp connections from being reset every 60 seconds.

Long term, we will be investigating keep alive to see if we can avoid setting an arbitrarily high value here. 

Changes
- bump chart version
- set proxy-read-timeout annotation in the ingress rule
- update ingress test case to use bindplane.local as the server / remote url

You can test with by deploying minikube w/ ingress

```bash
minikube start \
  --nodes 1 \
  --cpus 2 \
  --memory 4g  \
  --static-ip 192.168.49.2

minikube addons enable ingress

kubectl -n ingress-nginx wait deployment ingress-nginx-controller \
  --timeout=120s --for condition=Available=True
```

Deploy with Helm and Kubectl

```bash
helm template bpop \
  --values test/cases/ingress/values.yaml \
  charts/bindplane | \
  kubectl apply -f -
```

Check the ingress rule with

```bash
kubectl get ingress bpop-bindplane -o json | jq .metadata.annotations
```

Test a collector by adding the following to your `/etc/hosts`

```
192.168.49.2 bindplane.local
```

Check the output of `kubectl get ingress` until you see `address: 192.168.49.2`. This can take 30-60 seconds usually.

```
NAME             CLASS    HOSTS             ADDRESS        PORTS   AGE
bpop-bindplane   <none>   bindplane.local   192.168.49.2   80      31s
```

Open http://bindplane.local:80 and install a collector. The credentials will be `bpuser` / `bppass` as defined in the values.yaml file we used from the test case `test/cases/ingress/values.yaml`.

Create a config with the `otlp` source and `prometheus` exporter and attach it to the agent. This is to prevent the collector log file from being spammed by the default logging exporter, which is very verbose.

Tail the collector's log file

```bash
sudo tail -F /opt/observiq-otel-collector/log/collector.log
```

Wait 5 to 10 minutes (or an hour if you have the time). You should not see any errors related to opamp connections until exactly 1 hour, at which point the collector will reconnect.
