### PR TITLE
feat: Expose storage class option for bbolt backend

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an open source observability pipeline.
 type: application
 # The chart's version
-version: 0.0.24
+version: 0.0.25
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.13.0

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 0.0.19](https://img.shields.io/badge/Version-0.0.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.0](https://img.shields.io/badge/AppVersion-1.10.0-informational?style=flat-square)
+![Version: 0.0.24](https://img.shields.io/badge/Version-0.0.24-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.13.0](https://img.shields.io/badge/AppVersion-1.13.0-informational?style=flat-square)
 
 BindPlane OP is an open source observability pipeline.
 
@@ -37,6 +37,7 @@ BindPlane OP is an open source observability pipeline.
 | autoscaling.min | int | `2` | Minimum number of pods when autoscaling is enabled. |
 | autoscaling.targetCPUUtilizationPercentage | int | `60` | Autoscaling target CPU usage percentage. |
 | autoscaling.targetMemoryUtilizationPercentage | int | `60` | Autoscaling target Memory usage percentage. |
+| backend.bbolt.storageClass | string | `""` | The Kubernetes storage class to use for the volumeClaimTemplate. If unset, the volume claim will use the cluster's default storage class. |
 | backend.bbolt.volumeSize | string | `"10Gi"` | Persistent volume size. |
 | backend.postgres.database | string | `""` | Database to use. |
 | backend.postgres.host | string | `"localhost"` | Hostname or IP address of the Postgres server. |
@@ -47,10 +48,10 @@ BindPlane OP is an open source observability pipeline.
 | backend.postgres.username | string | `""` | Username to use when connecting to Postgres. |
 | backend.type | string | `"bbolt"` | Backend to use for persistent storage. Available options are `bbolt`, and `postgres` (Enterprise). |
 | config.password | string | `""` | Password to use. Overrides `config.secret`. |
-| config.remote_url | string | `"ws://bindplane-op:3001"` | URI used by agents to communicate with BindPlane using OpAMP. |
+| config.remote_url | string | `""` | URI used by agents to communicate with BindPlane using OpAMP. |
 | config.secret | string | `"bindplane"` | Name of the Kubernetes secret which contains the `username`, `password`, `secret_key`, and `sessions_secret` configuration options. |
 | config.secret_key | string | `""` | Secret Key to use. Overrides `config.secret`. |
-| config.server_url | string | `"http://bindplane-op:3001"` | URI used by clients to communicate with BindPlane. |
+| config.server_url | string | `""` | URI used by clients to communicate with BindPlane. |
 | config.sessions_secret | string | `""` | Sessions Secret to use. Overrides `config.secret`. |
 | config.username | string | `""` | Username to use. Overrides `config.secret`. |
 | email.sendgrid.token | string | `""` | The sendgrid API token to use when authenticating to Sendgrid. |

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -266,5 +266,8 @@ spec:
         resources:
           requests:
             storage: {{ .Values.backend.bbolt.volumeSize }}
+        {{- if .Values.backend.bbolt.storageClass }}
+        storageClassName: {{ .Values.backend.bbolt.storageClass }}
+        {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -11,6 +11,8 @@ backend:
   bbolt:
     # -- Persistent volume size.
     volumeSize: 10Gi
+    # -- The Kubernetes storage class to use for the volumeClaimTemplate. If unset, the volume claim will use the cluster's default storage class.
+    storageClass: ""
 
   postgres:
     # -- Hostname or IP address of the Postgres server.


### PR DESCRIPTION
Added the option to configure the bbolt volume claim template's storage class. This is useful for using non default storage class.

Changes
- Added storageClassName to volumeClaimTemplate config
- Added backend.bbolt.storageClass option to values.yaml
- Ran `helm-docs` to sync docs (past few releases have missed this)

GKE has the following by default.
```
NAME                     PROVISIONER             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
premium-rwo              pd.csi.storage.gke.io   Delete          WaitForFirstConsumer   true                   7m47s
standard                 kubernetes.io/gce-pd    Delete          Immediate              true                   7m46s
standard-rwo (default)   pd.csi.storage.gke.io   Delete          WaitForFirstConsumer   true                   7m46s
```

If left unset, the volume claim will use the "default" storage class, generally it is named `standard`.

Behavior is the same, if you do not set a storage class:
```
$ helm template charts/bindplane
...
  volumeClaimTemplates:
    - metadata:
        name: release-name-bindplane-data
        labels:
          app.kubernetes.io/name: bindplane
          app.kubernetes.io/stack: bindplane
          app.kubernetes.io/component: server
          app.kubernetes.io/instance: release-name
          app.kubernetes.io/managed-by: Helm
      spec:
        accessModes:
          - ReadWriteOnce
        resources:
          requests:
            storage: 10Gi
```
If you do set a storage class
```
$ helm template --set backend.bbolt.storageClass=premium-rwo charts/bindplane
...
  volumeClaimTemplates:
    - metadata:
        name: release-name-bindplane-data
        labels:
          app.kubernetes.io/name: bindplane
          app.kubernetes.io/stack: bindplane
          app.kubernetes.io/component: server
          app.kubernetes.io/instance: release-name
          app.kubernetes.io/managed-by: Helm
      spec:
        accessModes:
          - ReadWriteOnce
        resources:
          requests:
            storage: 10Gi
        storageClassName: premium-rwo
```