### PR TITLE
feat: Support configuring pod and container security context

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an open source observability pipeline.
 type: application
 # The chart's version
-version: 0.0.32
+version: 0.0.33
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.17.1

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -29,8 +29,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ include "bindplane.fullname" . }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        fsGroup: 65534
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: server
           image: {{ include "bindplane.image" . }}:{{ include "bindplane.tag" . }}
@@ -350,14 +352,10 @@ spec:
             httpGet:
               path: /health
               port: http
+          {{- with .Values.containerSecurityContext }}
           securityContext:
-            runAsNonRoot: true
-            runAsUser: 65534
-            # Persistent data is written to a volume, the bindplane process should
-            # never need to write to the container filesystem.
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             {{- if eq .Values.backend.type "bbolt" }}
             - mountPath: /data

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -211,3 +211,21 @@ email:
   sendgrid:
     # -- The sendgrid API token to use when authenticating to Sendgrid.
     token: ""
+
+# -- The Pod spec's securityContext: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod.
+podSecurityContext:
+  # This field supports all pod securityContext options.
+  # BindPlane uses the following container securityContext by default:
+  fsGroup: 65534
+
+# -- The Container's securityContext: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container.
+containerSecurityContext:
+  # This field supports all container securityContext options.
+  # BindPlane uses the following container securityContext by default:
+  runAsNonRoot: true
+  runAsUser: 65534
+  # Persistent data is written to a volume, the bindplane process should
+  # never need to write to the container filesystem.
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]


### PR DESCRIPTION
In an effort to support OpenShift, we need to make pod and container [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) configurable by the user. This PR moves the hardcoded securityContext options to two new sections in the values file.

```yaml
podSecurityContext:
  fsGroup: 65534

containerSecurityContext:
  runAsNonRoot: true
  runAsUser: 65534
  readOnlyRootFilesystem: true
  capabilities:
    drop: ["ALL"]
```

This change behaves identically by default, but allows user to modify securityContext.

Does not fully resolve OpenShift support, but this PR does address one of the first steps identified by a user here https://github.com/observIQ/bindplane-op-helm/issues/16