### PR TITLE
feat(dev): Support development collector

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an open source observability pipeline.
 type: application
 # The chart's version
-version: 0.0.44
+version: 0.0.45
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.23.0

--- a/charts/bindplane/templates/collector.yaml
+++ b/charts/bindplane/templates/collector.yaml
@@ -1,0 +1,97 @@
+{{- if .Values.dev.collector.create }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bindplane-test-agent
+  labels:
+    app.kubernetes.io/name: {{ include "bindplane.name" . }}
+    app.kubernetes.io/stack: bindplane
+    app.kubernetes.io/component: test-collector
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "bindplane.name" . }}
+      app.kubernetes.io/stack: bindplane
+      app.kubernetes.io/component: test-collector
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "bindplane.name" . }}
+        app.kubernetes.io/stack: bindplane
+        app.kubernetes.io/component: test-collector
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      initContainers:
+        - name: setup-volumes
+          image: {{ .Values.dev.collector.image.name }}:{{ .Values.dev.collector.image.tag }}
+          securityContext:
+            # Required for changing permissions from
+            # root to otel user in emptyDir volume.
+            runAsUser: 0
+          command:
+            - "chown"
+            - "otel:"
+            - "/etc/otel/config"
+          volumeMounts:
+            - mountPath: /etc/otel/config
+              name: config
+        - name: copy-configs
+          image: {{ .Values.dev.collector.image.name }}:{{ .Values.dev.collector.image.tag }}
+          command:
+            - 'sh'
+            - '-c'
+            - 'cp config.yaml config/ && cp logging.yaml config/ && chown -R otel:otel config/'
+          volumeMounts:
+            - mountPath: /etc/otel/config
+              name: config
+      containers:
+        - name: opentelemetry-container
+          image: {{ .Values.dev.collector.image.name }}:{{ .Values.dev.collector.image.tag }}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            readOnlyRootFilesystem: true
+          resources:
+            requests:
+              memory: 100Mi
+              cpu: 50m
+            limits:
+              memory: 100Mi
+          env:
+            - name: OPAMP_ENDPOINT
+              value: ws://{{ include "bindplane.fullname" . }}:3001/v1/opamp
+            - name: OPAMP_SECRET_KEY
+              value: {{ .Values.config.secret_key }}
+            - name: OPAMP_AGENT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPAMP_LABELS
+              value: {{ .Values.dev.collector.labels }}
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # The collector process updates config.yaml
+            # and manager.yaml when receiving changes
+            # from the OpAMP server.
+            - name: CONFIG_YAML_PATH
+              value: /etc/otel/config/config.yaml
+            - name: MANAGER_YAML_PATH
+              value: /etc/otel/config/manager.yaml
+            - name: LOGGING_YAML_PATH
+              value: /etc/otel/config/logging.yaml
+          volumeMounts:
+          - mountPath: /etc/otel/config
+            name: config
+          - mountPath: /etc/otel/storage
+            name: storage
+      volumes:
+        - name: config
+          emptyDir: {}
+        - name: storage
+          emptyDir: {}
+{{- end }}

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -254,3 +254,12 @@ dev:
     # resources to the namespace. Helm or ArgoCD will need to be configured
     # to use this namespace.
     name: ""
+
+  # Manages a collector deployment for development purposes.
+  collector:
+    # Whether or not the collector should be deployed.
+    create: false
+    image:
+      name: ghcr.io/observiq/observiq-otel-collector
+      tag: latest
+    labels: "configuration=test"


### PR DESCRIPTION
Adds an additional development parameter for deploying a managed collector. This collector is not suitable for production use. It lacks rbac configuration and it does not identify itself as a container based agent. It's intention is to allow developers to quickly deploy a collector with BindPlane OP.

When the values file contains the following, a collector will be deployed and automatically connect to bindplane.
```yaml
dev:
  collector:
    create: true
```