### PR TITLE
feat(dev): Add prometheus to dev mode

### DIFF
--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -240,6 +240,16 @@ spec:
             {{- end }}
             - name: BINDPLANE_PORT
               value: "3001"
+            {{- if .Values.prometheus.create }}
+            - name: BINDPLANE_PROMETHEUS_ENABLE
+              value: "true"
+            - name: BINDPLANE_PROMETHEUS_ENABLE_REMOTE
+              value: "true"
+            - name: BINDPLANE_PROMETHEUS_HOST
+              value: {{ .Values.prometheus.host }}}
+            - name: BINDPLANE_PROMETHEUS_PORT
+              value: {{ .Values.prometheus.port }}
+            {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -240,15 +240,15 @@ spec:
             {{- end }}
             - name: BINDPLANE_PORT
               value: "3001"
-            {{- if .Values.prometheus.create }}
+            {{- if .Values.prometheus.enable }}
             - name: BINDPLANE_PROMETHEUS_ENABLE
               value: "true"
             - name: BINDPLANE_PROMETHEUS_ENABLE_REMOTE
               value: "true"
             - name: BINDPLANE_PROMETHEUS_HOST
-              value: {{ .Values.prometheus.host }}}
+              value: {{ .Values.prometheus.host }}
             - name: BINDPLANE_PROMETHEUS_PORT
-              value: {{ .Values.prometheus.port }}
+              value: "{{ .Values.prometheus.port }}"
             {{- end }}
           {{- with .Values.resources }}
           resources:

--- a/charts/bindplane/templates/prometheus.yaml
+++ b/charts/bindplane/templates/prometheus.yaml
@@ -2,40 +2,31 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: bindplane-test-prometheus
+  name: {{ include "bindplane.fullname" . }}-prometheus
 data:
   # Both of these should be empty, but might contain
   # configuration in the future.
-  prometheus.yaml: |
-    []
-  web.yaml: |
+  prometheus.yml: |
+    # This is an empty config.
+  web.yml: |
+    # This is an empty config.
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: bindplane-test-prometheus
+  name: {{ include "bindplane.fullname" . }}-prometheus
   labels:
-    app.kubernetes.io/name: {{ include "bindplane.name" . }}
-    app.kubernetes.io/stack: bindplane
-    app.kubernetes.io/component: test-prometheus
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: test-prometheus
 spec:
   replicas: 1
   serviceName: bindplane-test-prometheus
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "bindplane.name" . }}
-      app.kubernetes.io/stack: bindplane
-      app.kubernetes.io/component: test-prometheus
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/name: test-prometheus
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "bindplane.name" . }}
-        app.kubernetes.io/stack: bindplane
-        app.kubernetes.io/component: test-prometheus
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/name: test-prometheus
     spec:
       containers:
         - name: opentelemetry-container
@@ -53,6 +44,10 @@ spec:
             - --storage.tsdb.retention.time=2d
           securityContext:
             readOnlyRootFilesystem: true
+          ports:
+            - name: http
+              containerPort: 9090
+              protocol: TCP
           resources:
             requests:
               memory: 300Mi
@@ -74,7 +69,7 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: bindplane-test-prometheus
+            name: {{ include "bindplane.fullname" . }}-prometheus
   # Delete persistent volumes when the statefulset is deleted.
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: Delete
@@ -83,11 +78,7 @@ spec:
     - metadata:
         name: tsdb
         labels:
-          app.kubernetes.io/name: {{ include "bindplane.name" . }}
-          app.kubernetes.io/stack: bindplane
-          app.kubernetes.io/component: test-prometheus
-          app.kubernetes.io/instance: {{ .Release.Name }}
-          app.kubernetes.io/managed-by: {{ .Release.Service }}
+          app.kubernetes.io/name: test-prometheus
       spec:
         accessModes:
           - ReadWriteOnce
@@ -98,12 +89,9 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: bindplane-test-prometheus
+  name: {{ include "bindplane.fullname" . }}-prometheus
   labels:
-    app.kubernetes.io/name: {{ include "bindplane.name" . }}
-    app.kubernetes.io/stack: bindplane
-    app.kubernetes.io/component: test-prometheus
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/name: test-prometheus
 spec:
   ports:
     - port: 9090
@@ -111,10 +99,7 @@ spec:
       targetPort: http
       name: http
   selector:
-    app.kubernetes.io/name: {{ include "bindplane.name" . }}
-    app.kubernetes.io/stack: bindplane
-    app.kubernetes.io/component: test-prometheus
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/name: test-prometheus
   sessionAffinity: None
   type: ClusterIP
 {{- end }}

--- a/charts/bindplane/templates/prometheus.yaml
+++ b/charts/bindplane/templates/prometheus.yaml
@@ -1,0 +1,120 @@
+{{- if .Values.dev.prometheus.create }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bindplane-test-prometheus
+data:
+  # Both of these should be empty, but might contain
+  # configuration in the future.
+  prometheus.yaml: |
+    []
+  web.yaml: |
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: bindplane-test-prometheus
+  labels:
+    app.kubernetes.io/name: {{ include "bindplane.name" . }}
+    app.kubernetes.io/stack: bindplane
+    app.kubernetes.io/component: test-prometheus
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: 1
+  serviceName: bindplane-test-prometheus
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "bindplane.name" . }}
+      app.kubernetes.io/stack: bindplane
+      app.kubernetes.io/component: test-prometheus
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "bindplane.name" . }}
+        app.kubernetes.io/stack: bindplane
+        app.kubernetes.io/component: test-prometheus
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: opentelemetry-container
+          image: {{ .Values.dev.prometheus.image.name }}:{{ .Values.dev.prometheus.image.tag }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/prometheus
+            - --web.listen-address=:9090
+            - --config.file=/etc/prometheus/prometheus.yml 
+            - --web.config.file=/etc/prometheus/web.yml
+            - --web.console.libraries=/usr/share/prometheus/console_libraries 
+            - --web.console.templates=/usr/share/prometheus/consoles
+            - --web.enable-remote-write-receiver
+            - --storage.tsdb.path=/prometheus
+            - --storage.tsdb.retention.time=2d
+          securityContext:
+            readOnlyRootFilesystem: true
+          resources:
+            requests:
+              memory: 300Mi
+              cpu: 100m
+            limits:
+              memory: 300Mi
+          volumeMounts:
+            # prometheus and web configuration
+            # from configmap.
+            - mountPath: /etc/prometheus/prometheus.yml
+              subPath: prometheus.yml
+              name: config
+            - mountPath: /etc/prometheus/web.yml
+              subPath: web.yml
+              name: config
+            # time series database persistent volume.
+            - mountPath: /prometheus
+              name: tsdb
+      volumes:
+        - name: config
+          configMap:
+            name: bindplane-test-prometheus
+  # Delete persistent volumes when the statefulset is deleted.
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  volumeClaimTemplates:
+    - metadata:
+        name: tsdb
+        labels:
+          app.kubernetes.io/name: {{ include "bindplane.name" . }}
+          app.kubernetes.io/stack: bindplane
+          app.kubernetes.io/component: test-prometheus
+          app.kubernetes.io/instance: {{ .Release.Name }}
+          app.kubernetes.io/managed-by: {{ .Release.Service }}
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 60Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bindplane-test-prometheus
+  labels:
+    app.kubernetes.io/name: {{ include "bindplane.name" . }}
+    app.kubernetes.io/stack: bindplane
+    app.kubernetes.io/component: test-prometheus
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  ports:
+    - port: 9090
+      protocol: TCP
+      targetPort: http
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "bindplane.name" . }}
+    app.kubernetes.io/stack: bindplane
+    app.kubernetes.io/component: test-prometheus
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  sessionAffinity: None
+  type: ClusterIP
+{{- end }}

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -27,6 +27,13 @@ backend:
     # -- Max number of connections to use when communicating with Postgres.
     maxConnections: 100
 
+  # TODO(jsirianni): Support authentication and TLS.
+  # This is undocumented for now, as Prometheus support has not been released.
+  prometheus:
+    enable: false
+    host: ""
+    port: 9090
+
 eventbus:
   # The eventbus type to use when BindPlane is deployed with multiple pods (Deployment). Available options include `pubsub`. By default, this option is not required as BindPlane OP operates as a StatefulSet with one pod.
   type: ""
@@ -301,3 +308,13 @@ dev:
       name: ghcr.io/observiq/observiq-otel-collector
       tag: latest
     labels: "configuration=test"
+  
+  # Manages a prometheus deployment for development purposes. Production
+  # deployments should use a proper prometheus backend deployed outside
+  # of this chart.
+  prometheus:
+    # Whether or not prometheus should be deployed.
+    create: false
+    image:
+      name: prom/prometheus
+      tag: v2.48.0


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Added a Prometheus StatefulSet for running Prometheus in a development environment. This configuration is not intended for production, and is undocumented.

Once Prometheus support is GA, a follow up PR will add the missing params (auth, tls, etc) and documentation for connecting to a remote Prometheus instance, likely deployed by the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator).

## Testing

Using minikube

I have the following values.yaml file

```yaml
dev:
  prometheus:
    create: true
  collector:
    create: true

prometheus:
  enable: true
  host: "release-name-bindplane-prometheus"
  port: "9090"

image:
  name: ghcr.io/observiq/bindplane-ee
  # This tag supports Prometheus
  tag: 09938a1b

config:
  username: bpuser
  password: bppass
  secret_key: 12D8FB6E-1532-4A4C-97AF-95A430BE5E6E
  sessions_secret: 4484766F-5016-4077-B8E0-0DE1D637854B
```

Using port forwarding, I create a config and assign it to the agent.
```bash
k port-forward pod/release-name-bindplane-0 3011:3001
```

http://localhost:3011

![Screenshot from 2023-12-05 16-32-55](https://github.com/observIQ/bindplane-op-helm/assets/23043836/402b9800-53b5-454a-811e-3de89a5992cf)
t:3011.

Pods
```bash
➜  bindplane-op-helm git:(dev/prometheus) ✗ k get pod
NAME                                                      READY   STATUS    RESTARTS   AGE
bindplane-test-agent-5bc749fb67-ftt89                     1/1     Running   0          4m58s
release-name-bindplane-0                                  1/1     Running   0          6m6s
release-name-bindplane-prometheus-0                       1/1     Running   0          8m56s
release-name-bindplane-transform-agent-65c4657494-ztt8j   1/1     Running   0          8m58s
```

Service points to the Prometheus pod
```bash
➜  bindplane-op-helm git:(dev/prometheus) ✗ k describe svc release-name-bindplane-prometheus    
Name:              release-name-bindplane-prometheus
Namespace:         default
Labels:            app.kubernetes.io/name=test-prometheus
Annotations:       <none>
Selector:          app.kubernetes.io/name=test-prometheus
Type:              ClusterIP
IP Family Policy:  SingleStack
IP Families:       IPv4
IP:                10.105.246.165
IPs:               10.105.246.165
Port:              http  9090/TCP
TargetPort:        http/TCP
Endpoints:         10.244.0.38:9090
Session Affinity:  None
Events:            <none>
```

If I delete the prometheus statefulset, bindplane begins logging measurement batcher failures

```
{"level":"error","timestamp":"2023-12-05T21:34:08.272Z","logger":"measurement_batcher","message":"Error while saving agent metrics","error":"put metrics: do request: Post \"http://release-name-bindplane-prometheus:9090/api/v1/write\": dial tcp 10.105.246.165:9090: connect: connection refused"}
```

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
