### PR TITLE
fix(prometheus): Set permissions on /prometheus

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an open source observability pipeline.
 type: application
 # The chart's version
-version: 1.0.8
+version: 1.0.9
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.36.0

--- a/charts/bindplane/templates/prometheus.yaml
+++ b/charts/bindplane/templates/prometheus.yaml
@@ -28,6 +28,19 @@ spec:
       labels:
         app.kubernetes.io/name: test-prometheus
     spec:
+      initContainers:
+        # Set permissions on /prometheus volume.
+        - name: setup-volumes
+          image: {{ .Values.dev.prometheus.image.name }}:{{ .Values.dev.prometheus.image.tag }}
+          securityContext:
+            runAsUser: 0
+          command:
+            - "chown"
+            - "65534:"
+            - "/prometheus"
+          volumeMounts:
+            - mountPath: /prometheus
+              name: tsdb
       containers:
         - name: opentelemetry-container
           image: {{ .Values.dev.prometheus.image.name }}:{{ .Values.dev.prometheus.image.tag }}


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

On GKE we get permission issues. Minikube works either way. The user id `65534` is what the prometheus process runs as, and maps to the `nobody` user.

```
/prometheus $ ls -la /prometheus/
total 20
drwxrwxrwx    4 nobody   nobody        4096 Dec  6 17:00 .
drwxr-xr-x    1 root     root          4096 Dec  6 17:00 ..
drwxr-xr-x    2 nobody   nobody        4096 Dec  6 16:57 chunks_head
-rw-r--r--    1 nobody   nobody           0 Dec  6 17:00 lock
-rw-r--r--    1 nobody   nobody       20001 Dec  6 17:00 queries.active
drwxr-xr-x    2 nobody   nobody        4096 Dec  6 17:00 wal
```

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
