### PR TITLE
chore(ci): Test against 1.25, 1.27, 1.29

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,9 @@ jobs:
           - "image"
           - "ingress"
         k8s_version:
-          - v1.24.0
           - v1.25.0
-          - v1.26.0
+          - v1.27.0
+          - v1.29.0
 
     steps:
       - name: Checkout


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Updated the test matrix to test against the latest release (1.29) as well as 1.25 and 1.27.

The k8s project maintains support for the last three minor versions, but we want to support a bit more than that. 

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
