### PR TITLE
feat(prometheus): Support all Prometheus parameters

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an open source observability pipeline.
 type: application
 # The chart's version
-version: 1.1.1
+version: 1.1.2
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.39.0

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.39.0](https://img.shields.io/badge/AppVersion-1.39.0-informational?style=flat-square)
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.39.0](https://img.shields.io/badge/AppVersion-1.39.0-informational?style=flat-square)
 
 BindPlane OP is an open source observability pipeline.
 
@@ -99,15 +99,28 @@ BindPlane OP is an open source observability pipeline.
 | ingress.tls.secret | string | `""` | Name of the Kubernetes secret which contains the TLS certificate. This secret must be created and managed outside of the Helm chart. See the [ingress TLS documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) for more details. |
 | multiAccount | bool | `false` | Whether or not to enable multi account (tenant). |
 | podSecurityContext | object | `{"fsGroup":65534}` | The Pod spec's securityContext: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod. |
+| prometheus.auth.password | string | `""` | Prometheus basic authentication password. |
+| prometheus.auth.type | string | `"none"` | Prometheus authentication. Supported options include `none` and `basic`. |
+| prometheus.auth.username | string | `""` | Prometheus basic authentication username. |
 | prometheus.enable | bool | `false` | when enabled, Prometheus will be used as the measurements backend. Prometheus is the recommended backend for production deployments. |
-| prometheus.enableSideCar | bool | `false` | When enabled, the Prometheus measurements backend will be deployed as a sidecar container. This option is only valid when BindPlane is running as a single node statefulset. |
-| prometheus.host | string | `"127.0.0.1"` | The Prometheus hostname or IP address. |
-| prometheus.port | int | `9090` | The Prometheus TCP port. |
+| prometheus.enableSideCar | bool | `false` | When enabled, the Prometheus measurements backend will be deployed as a sidecar container. This option is only valid when BindPlane is running as a single node statefulset. When using this option, leave all other Prometheus options unset and at their default values. |
+| prometheus.host | string | `"127.0.0.1"` | The Prometheus hostname or IP address used for querying and writing metrics. |
+| prometheus.port | int | `9090` | The Prometheus TCP port used for querying and writing metrics. |
+| prometheus.queryPathPrefix | string | `""` | Optional Prometheus query path prefix. Useful when overriding the query endpoints when using systems such as Mimir. |
+| prometheus.remoteWrite.host | string | `""` | Optional hostname or IP address of the remote write endpoint. This value overrides the `prometheus.host` for remote write. |
+| prometheus.remoteWrite.path | string | `"/api/v1/write"` | Path of the remote write endpoint. This value should default to `/api/v1/write`. |
+| prometheus.remoteWrite.port | int | `9090` | Optional TCP port of the remote write endpoint. This value overrides the `prometheus.port` for remote write. |
 | prometheus.sidecar.resources.limits.memory | string | `"500Mi"` | Memory limit. |
 | prometheus.sidecar.resources.requests.cpu | string | `"250m"` | CPU request. |
 | prometheus.sidecar.resources.requests.memory | string | `"250Mi"` | Memory request. |
 | prometheus.sidecar.storageClass | string | `""` | The Kubernetes storage class to use for the volumeClaimTemplate. If unset, the volume claim will use the cluster's default storage class. |
 | prometheus.sidecar.volumeSize | string | `"10Gi"` | Persistent volume size. |
+| prometheus.tls.enable | bool | `false` | Whether or not to use TLS when connecting to Prometheus. |
+| prometheus.tls.insecure | bool | `false` | Whether or not to skip verification of the Prometheus server's certificate. |
+| prometheus.tls.secret.caSubPath | string | `""` | The secret's subPath which contains the certificate authority. |
+| prometheus.tls.secret.crtSubPath | string | `""` | The secret's subPath which contains the client certificate, required for mutual TLS. |
+| prometheus.tls.secret.keySubPath | string | `""` | The secret's subPath which contains the client private key, required for mutual TLS. |
+| prometheus.tls.secret.name | string | `""` | Kubernetes TLS secret name that contains the Prometheus TLS certificate(s). |
 | resources.limits.memory | string | `"500Mi"` | Memory limit. |
 | resources.requests.cpu | string | `"250m"` | CPU request. |
 | resources.requests.memory | string | `"250Mi"` | Memory request. |

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.39.0](https://img.shields.io/badge/AppVersion-1.39.0-informational?style=flat-square)
+![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.39.0](https://img.shields.io/badge/AppVersion-1.39.0-informational?style=flat-square)
 
 BindPlane OP is an open source observability pipeline.
 

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -249,12 +249,16 @@ spec:
               value: {{ .Values.prometheus.host }}
             - name: BINDPLANE_PROMETHEUS_PORT
               value: "{{ .Values.prometheus.port }}"
+            {{- if .Values.prometheus.queryPathPrefix }}
             - name: BINDPLANE_PROMETHEUS_QUERY_PATH_PREFIX
               value: {{ .Values.prometheus.queryPathPrefix }}
+            {{- end }}
+            {{- if and (.Values.prometheus.remoteWrite.host) (.Values.prometheus.remoteWrite.port) }}
             - name: BINDPLANE_PROMETHEUS_REMOTE_WRITE_HOST
               value: {{ .Values.prometheus.remoteWrite.host }}
             - name: BINDPLANE_PROMETHEUS_REMOTE_WRITE_PORT
               value: "{{ .Values.prometheus.remoteWrite.port }}"
+            {{- end }}
             - name: BINDPLANE_PROMETHEUS_REMOTE_WRITE_ENDPOINT
               value: {{ .Values.prometheus.remoteWrite.path }}
             - name: BINDPLANE_PROMETHEUS_AUTH_TYPE

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -249,6 +249,34 @@ spec:
               value: {{ .Values.prometheus.host }}
             - name: BINDPLANE_PROMETHEUS_PORT
               value: "{{ .Values.prometheus.port }}"
+            - name: BINDPLANE_PROMETHEUS_QUERY_PATH_PREFIX
+              value: {{ .Values.prometheus.queryPathPrefix }}
+            - name: BINDPLANE_PROMETHEUS_REMOTE_WRITE_HOST
+              value: {{ .Values.prometheus.remoteWrite.host }}
+            - name: BINDPLANE_PROMETHEUS_REMOTE_WRITE_PORT
+              value: "{{ .Values.prometheus.remoteWrite.port }}"
+            - name: BINDPLANE_PROMETHEUS_REMOTE_WRITE_ENDPOINT
+              value: {{ .Values.prometheus.remoteWrite.path }}
+            - name: BINDPLANE_PROMETHEUS_AUTH_TYPE
+              value: {{ .Values.prometheus.auth.type }}
+            {{- if eq .Values.prometheus.auth.type "basic" }}
+            - name: BINDPLANE_PROMETHEUS_AUTH_USERNAME
+              value: {{ .Values.prometheus.auth.username }}
+            - name: BINDPLANE_PROMETHEUS_AUTH_PASSWORD
+              value: {{ .Values.prometheus.auth.password }}
+            {{- end }}
+            {{- if .Values.prometheus.tls.enable }}
+            - name: BINDPLANE_PROMETHEUS_ENABLE_TLS
+              value: "true"
+            - name: BINDPLANE_PROMETHEUS_TLS_SKIP_VERIFY
+              value: "{{ .Values.prometheus.tls.insecure }}"
+            - name: BINDPLANE_PROMETHEUS_TLS_CA
+              value: /prometheus-ca.crt
+            - name: BINDPLANE_PROMETHEUS_TLS_CERT
+              value: /prometheus-client.crt
+            - name: BINDPLANE_PROMETHEUS_TLS_KEY
+              value: /prometheus-client.key
+            {{- end }}
             {{- end }}
           {{- with .Values.resources }}
           resources:
@@ -306,6 +334,23 @@ spec:
               subPath: {{ .Values.eventbus.kafka.tls.secret.keySubPath }}
             {{- end }}
             {{- end }}
+            {{- if and (.Values.prometheus.enable) (.Values.prometheus.tls.enable) }}
+            {{- if .Values.prometheus.tls.secret.caSubPath }}
+            - mountPath: /prometheus-ca.crt
+              name: {{ .Values.prometheus.tls.secret.name }}
+              subPath: {{ .Values.prometheus.tls.secret.caSubPath }}
+            {{- end }}
+            {{- if .Values.prometheus.tls.secret.crtSubPath }}
+            - mountPath: /prometheus-client.crt
+              name: {{ .Values.prometheus.tls.secret.name }}
+              subPath: {{ .Values.prometheus.tls.secret.crtSubPath }}
+            {{- end }}
+            {{- if .Values.prometheus.tls.secret.keySubPath }}
+            - mountPath: /prometheus-client.key
+              name: {{ .Values.prometheus.tls.secret.name }}
+              subPath: {{ .Values.prometheus.tls.secret.keySubPath }}
+            {{- end }}
+            {{- end }}
           lifecycle:
             preStop:
               exec:
@@ -330,6 +375,11 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: {{ include "bindplane.fullname" . }}-prometheus-config
               mountPath: /etc/prometheus/prometheus.yml

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -430,6 +430,14 @@ spec:
             secretName: {{ .Values.eventbus.kafka.tls.secret.name }}
         {{- end }}
         {{- end }}
+        {{- if and (.Values.prometheus.enable) (.Values.prometheus.tls.enable) }}
+        {{- if .Values.prometheus.tls.secret.name }}
+        - name: {{ .Values.prometheus.tls.secret.name }}
+          secret:
+            defaultMode: 0400
+            secretName: {{ .Values.prometheus.tls.secret.name }}
+        {{- end }}
+        {{- end }}
         {{- if eq (include "bindplane.deployment_type" .) "StatefulSet" }}
         {{- if and (.Values.prometheus.enable) (.Values.prometheus.enableSideCar) }}
         - name: {{ include "bindplane.fullname" . }}-prometheus-config

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -388,6 +388,7 @@ spec:
           securityContext:
             runAsNonRoot: true
             readOnlyRootFilesystem: true
+            runAsUser: 65534
             capabilities:
               drop: ["ALL"]
           volumeMounts:

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -274,12 +274,18 @@ spec:
               value: "true"
             - name: BINDPLANE_PROMETHEUS_TLS_SKIP_VERIFY
               value: "{{ .Values.prometheus.tls.insecure }}"
+            {{- if .Values.prometheus.tls.secret.caSubPath }}
             - name: BINDPLANE_PROMETHEUS_TLS_CA
               value: /prometheus-ca.crt
+            {{- end }}
+            {{- if .Values.prometheus.tls.secret.crtSubPath }}
             - name: BINDPLANE_PROMETHEUS_TLS_CERT
               value: /prometheus-client.crt
+            {{- end }}
+            {{- if .Values.prometheus.tls.secret.keySubPath }}
             - name: BINDPLANE_PROMETHEUS_TLS_KEY
               value: /prometheus-client.key
+            {{- end }}
             {{- end }}
             {{- end }}
           {{- with .Values.resources }}

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -32,11 +32,41 @@ backend:
 prometheus:
   # -- when enabled, Prometheus will be used as the measurements backend. Prometheus is the recommended backend for production deployments.
   enable: false
-  # -- The Prometheus hostname or IP address.
+  # -- The Prometheus hostname or IP address used for querying and writing metrics.
   host: "127.0.0.1"
-  # -- The Prometheus TCP port.
+  # -- The Prometheus TCP port used for querying and writing metrics.
   port: 9090
-  # -- When enabled, the Prometheus measurements backend will be deployed as a sidecar container. This option is only valid when BindPlane is running as a single node statefulset.
+  # -- Optional Prometheus query path prefix. Useful when overriding the query endpoints when using systems such as Mimir.
+  queryPathPrefix: ""
+  remoteWrite:
+    # -- Optional hostname or IP address of the remote write endpoint. This value overrides the `prometheus.host` for remote write.
+    host: ""
+    # -- Optional TCP port of the remote write endpoint. This value overrides the `prometheus.port` for remote write.
+    port: 9090
+    # -- Path of the remote write endpoint. This value should default to `/api/v1/write`.
+    path: /api/v1/write
+  auth:
+    # -- Prometheus authentication. Supported options include `none` and `basic`.
+    type: none
+    # -- Prometheus basic authentication username.
+    username: ""
+    # -- Prometheus basic authentication password.
+    password: ""
+  tls:
+    # -- Whether or not to use TLS when connecting to Prometheus.
+    enable: false
+    # -- Whether or not to skip verification of the Prometheus server's certificate.
+    insecure: false
+    secret:
+      # -- Kubernetes TLS secret name that contains the Prometheus TLS certificate(s).
+      name: ""
+      # -- The secret's subPath which contains the certificate authority.
+      caSubPath: ""
+      # -- The secret's subPath which contains the client certificate, required for mutual TLS.
+      crtSubPath: ""
+      # -- The secret's subPath which contains the client private key, required for mutual TLS.
+      keySubPath: ""
+  # -- When enabled, the Prometheus measurements backend will be deployed as a sidecar container. This option is only valid when BindPlane is running as a single node statefulset. When using this option, leave all other Prometheus options unset and at their default values.
   enableSideCar: false
   sidecar:
     resources:

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -57,6 +57,18 @@ prometheus:
     enable: false
     # -- Whether or not to skip verification of the Prometheus server's certificate.
     insecure: false
+    # The TLS secret should be created like this:
+    #
+    # kubectl create secret generic prometheus-tls \
+    #   --from-file prometheus-client.crt \
+    #   --from-file prometheus-client.key \
+    #   --from-file ca.crt
+    #
+    # In this example, the following parameters would be used:
+    # prometheus.tls.secret.name: prometheus-tls
+    # prometheus.tls.secret.caSubPath: ca.crt
+    # prometheus.tls.secret.crtSubPath: prometheus-client.crt (if mutual tls is required)
+    # prometheus.tls.secret.keySubPath: prometheus-client.key (if mutual tls is required)
     secret:
       # -- Kubernetes TLS secret name that contains the Prometheus TLS certificate(s).
       name: ""


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Added support for
- Query Path Prefix
- Remote Write Host, port, and path (endpoint)
- Auth
- TLS

## Testing

### Prometheus

I followed our [Prometheus Installation](https://observiq.com/docs/going-to-production/bindplane/prometheus#self-managed-prometheus) documentation when building my Prometheus test system.

Chart deployed from the branch with:
```bash
helm template \
  --namespace default \
  --values values.yaml \
  bindplane \
  charts/bindplane | kubectl apply -f - 
```

Port forwarding used to connect to the ui on port 3011.

```bash
kubectl port-forward pod/bindplane-0 3011:3001
```

Tested by ensuring topology view has active measurements.

#### Default Prometheus Install

```yaml
config:
  username: bpuser
  password: bppass
  secret_key: 12D8FB6E-1532-4A4C-97AF-95A430BE5E6E
  sessions_secret: 4484766F-5016-4077-B8E0-0DE1D637854B
prometheus:
  enable: true
  host: prometheus-tls.c.bpcli-dev.internal
dev:
  collector:
    create: true
```

#### Basic Auth

Web.yaml config
```yaml
basic_auth_users:
  admin: $2b$12$maOicLymWgsIQleRCm604ePbaaavp9cKj3bJUg0IrcVXCHB3terLa
```

```yaml
config:
  username: bpuser
  password: bppass
  secret_key: 12D8FB6E-1532-4A4C-97AF-95A430BE5E6E
  sessions_secret: 4484766F-5016-4077-B8E0-0DE1D637854B
prometheus:
  enable: true
  host: prometheus-tls.c.bpcli-dev.internal
  auth:
    type: basic
    username: admin
    password: password
dev:
  collector:
    create: true
```

#### TLS

I used step cli to create a CA and signed certificate for my host `prometheus-tls.c.bpcli-dev.internal`.

I configured web.yml on the prometheus server with:

```yaml
tls_server_config:
  cert_file: /etc/prometheus/tls/prometheus.crt
  key_file: /etc/prometheus/tls/prometheus.key
```

I then created a secret with:

```bash
kubectl create secret generic prometheus-tls \     
  --from-file ca.crt 
```

```yaml
config:
  username: bpuser
  password: bppass
  secret_key: 12D8FB6E-1532-4A4C-97AF-95A430BE5E6E
  sessions_secret: 4484766F-5016-4077-B8E0-0DE1D637854B
prometheus:
  enable: true
  host: prometheus-tls.c.bpcli-dev.internal
  tls:
    enable: true
    insecure: false
    secret:
      name: prometheus-tls
      caSubPath: ca.crt
dev:
  collector:
    create: true
```

TLS is tested by configuring the ca and keeping skip verify set to false.

#### Mutual TLS

I used step cli to create another signed certificate, this time the keypair is used for bindplane's client auth.

The client auth type and client ca file were configured like this:

```yaml
tls_server_config:
  client_auth_type: RequireAndVerifyClientCert
  client_ca_file: /etc/prometheus/tls/ca.crt
  cert_file: /etc/prometheus/tls/prometheus.crt
  key_file: /etc/prometheus/tls/prometheus.key
```

After restarting prometheus, bindplane starts logging client auth errors (Expected, bindplane does not have a client keypair configured yet)

```
{"level":"error","timestamp":"2024-01-12T02:56:36.030Z","message":"failed to get configurationMetrics","error":"query: query: Post \"https://prometheus-tls.c.bpcli-dev.internal:9090/api/v1/query\": remote error: tls: certificate required"}
```

I created the secret with the bindplane client keypair and the ca

```bash
kubectl create secret generic prometheus-tls \
  --from-file prometheus-client.crt \     
  --from-file prometheus-client.key \     
  --from-file ca.crt 
```

```yaml
config:
  username: bpuser
  password: bppass
  secret_key: 12D8FB6E-1532-4A4C-97AF-95A430BE5E6E
  sessions_secret: 4484766F-5016-4077-B8E0-0DE1D637854B
prometheus:
  enable: true
  host: prometheus-tls.c.bpcli-dev.internal
  tls:
    enable: true
    insecure: false
    secret:
      name: prometheus-tls
      caSubPath: ca.crt
      crtSubPath: prometheus-client.crt
      keySubPath: prometheus-client.key
dev:
  collector:
    create: true
```

### Mimir

Using our in house tooling, I deployed mimir to my test cluster with:

```bash
kubectl create ns mimir
kustomize build app/priority-class/base | kubectl apply -f -
kustomize build app/mimir/environments/local | kubectl apply --namespace mimir -f -
```

The mimir config requires the following be set
- `prometheus.host`
- `prometheus.port`
- `prometheus.queryPathPrefix`
- `prometheus.remoteWrite.host`
- `prometheus.remoteWrite.port`
- `prometheus.remoteWrite.path`

The query host and remote write host are not the same.

```yaml
config:
  username: bpuser
  password: bppass
  secret_key: 12D8FB6E-1532-4A4C-97AF-95A430BE5E6E
  sessions_secret: 4484766F-5016-4077-B8E0-0DE1D637854B
prometheus:
  enable: true
  host: mimir-query-frontend.mimir.svc.cluster.local
  port: 8080
  queryPathPrefix: /prometheus
  remoteWrite:
    host: mimir-distributor-headless.mimir.svc.cluster.local
    port: 8080
    path: /api/v1/push
dev:
  collector:
    create: true
```

I did not use our recording rule with mimir, so measurements are not exactly working 100% but I did confirm that remote write + query endpoints are working. No errors from bindplane, agents page does show measurements on a brand new install of bindplane.


## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
