### PR TITLE
feat: Boost default resources and support configuring healthcheck probes

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an open source observability pipeline.
 type: application
 # The chart's version
-version: 1.1.5
+version: 1.1.6
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.42.0

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -89,6 +89,9 @@ BindPlane OP is an open source observability pipeline.
 | eventbus.pubsub.projectid | string | `""` |  |
 | eventbus.pubsub.topic | string | `""` |  |
 | eventbus.type | string | `""` |  |
+| health.livenessProbe | object | `{"httpGet":{"path":"/health","port":"http"}}` | Full configuration for livenessProbe. Supports all options documented here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/. |
+| health.readinessProbe | object | `{"httpGet":{"path":"/health","port":"http"}}` | Full configuration for readinessProbe. Supports all options documented here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/. |
+| health.startupProbe | object | `{"httpGet":{"path":"/health","port":"http"}}` | Full configuration for startupProbe. Supports all options documented here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/. |
 | image.name | string | `""` | Image name to be used. Defaults to `ghcr.io/observiq/bindplane-ee`. |
 | image.tag | string | `""` | Image tag to use. Defaults to the version defined in the Chart's release. |
 | ingress.annotations | object | `{}` | Custom annotations which will be added to the ingress object. Useful for specifying things such as `cert-manager.io/cluster-issuer`. |
@@ -121,9 +124,9 @@ BindPlane OP is an open source observability pipeline.
 | prometheus.tls.secret.crtSubPath | string | `""` | The secret's subPath which contains the client certificate, required for mutual TLS. |
 | prometheus.tls.secret.keySubPath | string | `""` | The secret's subPath which contains the client private key, required for mutual TLS. |
 | prometheus.tls.secret.name | string | `""` | Kubernetes TLS secret name that contains the Prometheus TLS certificate(s). |
-| resources.limits.memory | string | `"500Mi"` | Memory limit. |
-| resources.requests.cpu | string | `"250m"` | CPU request. |
-| resources.requests.memory | string | `"250Mi"` | Memory request. |
+| resources.limits.memory | string | `"1000Mi"` | Memory limit. |
+| resources.requests.cpu | string | `"1000m"` | CPU request. |
+| resources.requests.memory | string | `"1000Mi"` | Memory request. |
 | trace.otlp.endpoint | string | `""` | Endpoint of the OTLP trace receiver. Should be in the form of ip:port or host:port. |
 | trace.otlp.insecure | bool | `false` | Set to `true` to disable TLS. Set to false if TLS is in use by the OTLP trace receiver. |
 | trace.type | string | `""` | Trace type to use. Valid options include `otlp`. |

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -292,18 +292,18 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.startupProbe }}
           startupProbe:
-            httpGet:
-              path: /health
-              port: http
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
           readinessProbe:
-            httpGet:
-              path: /health
-              port: http
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
           livenessProbe:
-            httpGet:
-              path: /health
-              port: http
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -292,15 +292,15 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.startupProbe }}
+          {{- with .Values.health.startupProbe }}
           startupProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.readinessProbe }}
+          {{- with .Values.health.readinessProbe }}
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.livenessProbe }}
+          {{- with .Values.health.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -281,21 +281,22 @@ resources:
     # Disable cpu limit by default, for burstable qos class
     # cpu: 1000m
 
-# -- Full configuration for startupProbe. Supports all options documented here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/.
-startupProbe:
-  httpGet:
-    path: /health
-    port: http
-# -- Full configuration for readinessProbe. Supports all options documented here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/.
-readinessProbe:
-  httpGet:
-    path: /health
-    port: http
-# -- Full configuration for livenessProbe. Supports all options documented here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/.
-livenessProbe:
-  httpGet:
-    path: /health
-    port: http
+health:
+  # -- Full configuration for startupProbe. Supports all options documented here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/.
+  startupProbe:
+    httpGet:
+      path: /health
+      port: http
+  # -- Full configuration for readinessProbe. Supports all options documented here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/.
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: http
+  # -- Full configuration for livenessProbe. Supports all options documented here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/.
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: http
 
 ingress:
   # -- Whether or not to enable ingress.

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -281,6 +281,22 @@ resources:
     # Disable cpu limit by default, for burstable qos class
     # cpu: 1000m
 
+# -- Full configuration for startupProbe. Supports all options documented here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/.
+startupProbe:
+  httpGet:
+    path: /health
+    port: http
+# -- Full configuration for readinessProbe. Supports all options documented here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/.
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+# -- Full configuration for livenessProbe. Supports all options documented here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/.
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+
 ingress:
   # -- Whether or not to enable ingress.
   enable: false

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -272,14 +272,14 @@ config:
 resources:
   requests:
     # -- Memory request.
-    memory: 250Mi
+    memory: 1000Mi
     # -- CPU request.
-    cpu: 250m
+    cpu: 1000m
   limits:
     # -- Memory limit.
-    memory: 500Mi
+    memory: 1000Mi
     # Disable cpu limit by default, for burstable qos class
-    # cpu: 500m
+    # cpu: 1000m
 
 ingress:
   # -- Whether or not to enable ingress.


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

On slower systems, bindplane can fail to deploy because it takes too long to startup. The default cpu / memory values are too low in general, and [fall outside of our recommended sizing](https://observiq.com/docs/advanced-setup/installation/prerequisites).

To combat this, I have boosted the default resources and exposed each healthcheck in the values file.

- Boosted default CPU request to `1000m` (one core)
- Boosted default memory request to `1000Mi`
- Boosted default memory limit to `1000Mi`
- Exposed startup, readiness, and liveness probes in the values file

## Testing

First, deploy the `main` branch in order to test upgrading to this branch.

```bash
minikube start
```

Create `values.yaml` file:

```yaml
config:
  username: bpuser
  password: bppass
  secret_key: 12D8FB6E-1532-4A4C-97AF-95A430BE5E6E
  sessions_secret: 4484766F-5016-4077-B8E0-0DE1D637854B
prometheus:
  enable: true
  enableSideCar: true
dev:
  collector:
    create: true
```

Deploy with:

```bash
helm --values values.yaml template charts/bindplane | k apply -f -
```

Wait for the pods to startup. `kubectl get pod -n default`.

Once stabilized, you can checkout this branch and re-run the `helm template` command. You should see the bindplane pod and the transform pod restarting, with new resource values.

You can view the rendered yaml using helm template without piping to kubectl.

```bash
helm --values values.yaml template charts/bindplane
```

If you inspect the yaml output, you will see that the healthcheck probes have the correct configuration.

You can log into bindplane with:

```bash
kubectl port-forward \
  pod/release-name-bindplane-0 3011:3001 \
  --address 0.0.0.0
```

Navigate to http://localhost:3011 and login with `bpuser` / `bppass`. 

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
