### PR TITLE
feat(prometheus): Always enable Prometheus

### DIFF
--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -364,7 +364,6 @@ spec:
               exec:
                 command: ["sh", "-c", "sleep 5",]
         {{- if eq (include "bindplane.deployment_type" .) "StatefulSet" }}
-        {{- if eq .Values.prometheus.remote false }}
         - name: prometheus
           image: ghcr.io/observiq/bindplane-prometheus:{{ include "bindplane.tag" . }}
           ports:
@@ -383,7 +382,6 @@ spec:
           volumeMounts:
             - name: {{ include "bindplane.fullname" . }}-prometheus-data
               mountPath: /prometheus
-        {{- end }}
         {{- end }}
       terminationGracePeriodSeconds: 60
       volumes:
@@ -441,7 +439,6 @@ spec:
         {{- end }}
     {{- end }}
     {{- if eq (include "bindplane.deployment_type" .) "StatefulSet" }}
-    {{- if eq .Values.prometheus.remote false }}
     - metadata:
         name: {{ include "bindplane.fullname" . }}-prometheus-data
         labels:
@@ -459,6 +456,5 @@ spec:
         {{- if .Values.prometheus.sidecar.storageClass }}
         storageClassName: {{ .Values.prometheus.sidecar.storageClass }}
         {{- end }}
-      {{- end }}
       {{- end }}
   {{- end }}

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -240,7 +240,6 @@ spec:
             {{- end }}
             - name: BINDPLANE_PORT
               value: "3001"
-            {{- if .Values.prometheus.enable }}
             - name: BINDPLANE_PROMETHEUS_ENABLE
               value: "true"
             - name: BINDPLANE_PROMETHEUS_ENABLE_REMOTE
@@ -285,7 +284,6 @@ spec:
             {{- if .Values.prometheus.tls.secret.keySubPath }}
             - name: BINDPLANE_PROMETHEUS_TLS_KEY
               value: /prometheus-client.key
-            {{- end }}
             {{- end }}
             {{- end }}
           {{- with .Values.resources }}
@@ -344,7 +342,7 @@ spec:
               subPath: {{ .Values.eventbus.kafka.tls.secret.keySubPath }}
             {{- end }}
             {{- end }}
-            {{- if and (.Values.prometheus.enable) (.Values.prometheus.tls.enable) }}
+            {{- if .Values.prometheus.tls.enable }}
             {{- if .Values.prometheus.tls.secret.caSubPath }}
             - mountPath: /prometheus-ca.crt
               name: {{ .Values.prometheus.tls.secret.name }}
@@ -366,7 +364,7 @@ spec:
               exec:
                 command: ["sh", "-c", "sleep 5",]
         {{- if eq (include "bindplane.deployment_type" .) "StatefulSet" }}
-        {{- if and (.Values.prometheus.enable) (.Values.prometheus.enableSideCar) }}
+        {{- if eq .Values.prometheus.remote false }}
         - name: prometheus
           image: ghcr.io/observiq/bindplane-prometheus:{{ include "bindplane.tag" . }}
           ports:
@@ -413,7 +411,7 @@ spec:
             secretName: {{ .Values.eventbus.kafka.tls.secret.name }}
         {{- end }}
         {{- end }}
-        {{- if and (.Values.prometheus.enable) (.Values.prometheus.tls.enable) }}
+        {{- if .Values.prometheus.tls.enable }}
         {{- if .Values.prometheus.tls.secret.name }}
         - name: {{ .Values.prometheus.tls.secret.name }}
           secret:
@@ -443,7 +441,7 @@ spec:
         {{- end }}
     {{- end }}
     {{- if eq (include "bindplane.deployment_type" .) "StatefulSet" }}
-    {{- if and (.Values.prometheus.enable) (.Values.prometheus.enableSideCar) }}
+    {{- if eq .Values.prometheus.remote false }}
     - metadata:
         name: {{ include "bindplane.fullname" . }}-prometheus-data
         labels:

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -27,11 +27,9 @@ backend:
     # -- Max number of connections to use when communicating with Postgres.
     maxConnections: 100
 
-# TODO(jsirianni): Support authentication and TLS.
-# This is undocumented for now, as Prometheus support has not been released.
 prometheus:
-  # -- when enabled, Prometheus will be used as the measurements backend. Prometheus is the recommended backend for production deployments.
-  enable: false
+  # -- When enabled, the chart will not deploy a Prometheus instance. This option is useful when using an existing Prometheus instance.
+  remote: false
   # -- The Prometheus hostname or IP address used for querying and writing metrics.
   host: "127.0.0.1"
   # -- The Prometheus TCP port used for querying and writing metrics.
@@ -78,8 +76,7 @@ prometheus:
       crtSubPath: ""
       # -- The secret's subPath which contains the client private key, required for mutual TLS.
       keySubPath: ""
-  # -- When enabled, the Prometheus measurements backend will be deployed as a sidecar container. This option is only valid when BindPlane is running as a single node statefulset. When using this option, leave all other Prometheus options unset and at their default values.
-  enableSideCar: false
+  # -- When BindPlane is running in single instance mode and `prometheus.remote` is set to `false`, the measurements backend will be deployed as a sidecar container.
   sidecar:
     resources:
       requests:

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -28,8 +28,6 @@ backend:
     maxConnections: 100
 
 prometheus:
-  # -- When enabled, the chart will not deploy a Prometheus instance. This option is useful when using an existing Prometheus instance.
-  remote: false
   # -- The Prometheus hostname or IP address used for querying and writing metrics.
   host: "127.0.0.1"
   # -- The Prometheus TCP port used for querying and writing metrics.
@@ -76,7 +74,6 @@ prometheus:
       crtSubPath: ""
       # -- The secret's subPath which contains the client private key, required for mutual TLS.
       keySubPath: ""
-  # -- When BindPlane is running in single instance mode and `prometheus.remote` is set to `false`, the measurements backend will be deployed as a sidecar container.
   sidecar:
     resources:
       requests:


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

- Removed `prometheus.enable` option
- Removed `prometheus.enableSidecar` option

The intention is to always configure BindPlane to use Prometheus.

## Migration path

### Configuration

The following options can be removed from a user's values configuration:
- `prometheus.enable`
- `prometheus.enableSidecar`

### StatefulSet

Single instance StatefulSet deployments can be upgraded without issue regardless of their Prometheus status.

Existing StatefulSets without Prometheus will be upgraded without issue. The new pod will contain a sidecar (additional container within the bindplane pod).

Existing StatefulSets with `prometheus.enableSidecar` set will be upgraded without issue and continue to use their sidecar.

### Deployment (High Availability)

When running as a Deployment, the chart will not deploy Prometheus as a sidecar, because this would result in one Prometheus container per pod in the deployment. It is expected that Deployment users will configure a remote Prometheus server on their own, separate from this chart.

Existing Deployments without Prometheus will start up fine but will not function until Prometheus is correctly configured.

Existing Deployments that contain Prometheus will continue to use Prometheus without issue.

## Testing

### Single Instance

#### Prometheus Previously Enabled

Single instance testing is easy because the output from helm is the same as before if Prometheus was already enabled. 

1. Checkout `always-on-prometheus`
2. Create values.yaml with the Prometheus options
```yaml
image:
  tag: 1.43.0
config:
  username: bpuser
  password: bppass
  secret_key: 12D8FB6E-1532-4A4C-97AF-95A430BE5E6E
  sessions_secret: 4484766F-5016-4077-B8E0-0DE1D637854B
prometheus:
  enable: true
  enableSideCar: true
dev:
  collector:
    create: true
```
3. Write the helm output to a file:
```bash
helm template --values ./values.yaml charts/bindplane > old.yaml
```

4. Checkout this branch
5. Remove the `prometheus` options from the values file
6. Write the helm output to a file:
```bash
helm template --values ./values.yaml charts/bindplane > new.yaml
```

Diff the results
```bash
diff new.yaml old.yaml
```

Or checksum them:

```bash
$ sha256sum new.yaml old.yaml

33cf5913fcaff8270571a29d250f7379f67f84c69b1326350a4e94505a8037a8  new.yaml
33cf5913fcaff8270571a29d250f7379f67f84c69b1326350a4e94505a8037a8  old.yaml
```

#### Prometheus Not Enabled

If Prometheus was not enabled previously, you can use the following values file to deploy main and then upgrade to this branch:

```yaml
image:
  tag: 1.43.0
config:
  username: bpuser
  password: bppass
  secret_key: 12D8FB6E-1532-4A4C-97AF-95A430BE5E6E
  sessions_secret: 4484766F-5016-4077-B8E0-0DE1D637854B
dev:
  collector:
    create: true
```

Deploy the `epic/always-on-prometheus` branch to minikube (the branch we are merging into)
```bash
git checkout epic/always-on-prometheus
helm template --values ./values.yaml charts/bindplane | kubectl apply -f -
```

Note that bindplane has a single container (does not have a Prometheus sidecar container).

```bash
$ kubectl get pod

NAME                                                      READY   STATUS    RESTARTS   AGE
bindplane-test-agent-5bc749fb67-9vwr6                     1/1     Running   0          21m
release-name-bindplane-0                                  1/1     Running   0          21m
release-name-bindplane-transform-agent-59d7657d8f-gl5b2   1/1     Running   0          21m
```

Upgrading can be done by deleting the statefulset and re-deploying. The delete is necessary due to the addition of a sidecar container. See this [previous PR for details on why this is safe](https://github.com/observIQ/bindplane-op-helm/pull/88).

```bash
git checkout single-instance-prometheus-always-on
kubectl delete sts release-name-bindplane   
template --values ./values.yaml charts/bindplane | kubectl apply -f -
```

Once deployed, the bindplane pod will contain two containers.

```
NAME                                                      READY   STATUS    RESTARTS   AGE
bindplane-test-agent-5bc749fb67-9vwr6                     1/1     Running   0          25m
release-name-bindplane-0                                  2/2     Running   0          78s
release-name-bindplane-transform-agent-59d7657d8f-gl5b2   1/1     Running   0          25m
```

### High Availability

WIP

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
