### PR TITLE
WIP: Add NATS event bus support

### DIFF
--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -14,6 +14,16 @@ spec:
   replicas: 1
   serviceName: {{ include "bindplane.fullname" . }}
   {{- end }}
+  {{- if eq (include "bindplane.deployment_type" .) "Deployment" }}
+  {{- if eq .Values.autoscaling.enable false }}
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  {{- end }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "bindplane.name" . }}
@@ -132,6 +142,42 @@ spec:
             - name: BINDPLANE_STORE_BBOLT_PATH
               value: /data/storage
             {{- end }}
+            {{- if eq .Values.eventbus.type "nats" }}
+            - name: BINDPLANE_EVENT_BUS_TYPE
+              value: nats
+            - name: BINDPLANE_NATS_SERVER_ENABLE
+              value: "true"
+            - name: BINDPLANE_NATS_SERVER_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: BINDPLANE_NATS_SERVER_CLIENT_HOST
+              value: "127.0.0.1"
+            - name: BINDPLANE_NATS_SERVER_CLIENT_PORT
+              value: "4222"
+            - name: BINDPLANE_NATS_SERVER_HTTP_HOST
+              value: "127.0.0.1"
+            - name: BINDPLANE_NATS_SERVER_HTTP_PORT
+              value: "8222"
+            - name: BINDPLANE_NATS_SERVER_CLUSTER_NAME
+              value: {{ include "bindplane.name" . }}
+            - name: BINDPLANE_NATS_SERVER_CLUSTER_HOST
+              value: "0.0.0.0"
+            - name: BINDPLANE_NATS_SERVER_CLUSTER_PORT
+              value: "6222"
+            - name: BINDPLANE_NATS_SERVER_CLUSTER_ADVERTISE
+              value: "{{ include "bindplane.fullname" . }}-nats-headless.{{ .Release.Namespace }}.svc.cluster.local:6222"
+            - name: BINDPLANE_NATS_SERVER_CLUSTER_ROUTES
+              value: "nats://{{ include "bindplane.fullname" . }}-nats-headless.{{ .Release.Namespace }}.svc.cluster.local:6222"
+            - name: BINDPLANE_NATS_CLIENT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: BINDPLANE_NATS_CLIENT_ENDPOINT
+              value: "nats://localhost:4222"
+            - name: BINDPLANE_NATS_CLIENT_SUBJECT
+              value: "bindplane-event-bus"
+            {{- end}}
             {{- if eq .Values.eventbus.type "pubsub" }}
             - name: BINDPLANE_EVENT_BUS_TYPE
               value: googlePubSub

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -165,8 +165,6 @@ spec:
               value: "0.0.0.0"
             - name: BINDPLANE_NATS_SERVER_CLUSTER_PORT
               value: "6222"
-            - name: BINDPLANE_NATS_SERVER_CLUSTER_ADVERTISE
-              value: "{{ include "bindplane.fullname" . }}-nats-headless.{{ .Release.Namespace }}.svc.cluster.local:6222"
             - name: BINDPLANE_NATS_SERVER_CLUSTER_ROUTES
               value: "nats://{{ include "bindplane.fullname" . }}-nats-headless.{{ .Release.Namespace }}.svc.cluster.local:6222"
             - name: BINDPLANE_NATS_CLIENT_NAME

--- a/charts/bindplane/templates/hpa.yaml
+++ b/charts/bindplane/templates/hpa.yaml
@@ -1,4 +1,5 @@
 {{- if and (eq .Values.autoscaling.enable true) (include "bindplane.deployment_type" .) "Deployment" }}
+{{- if not eq .Values.eventbus.type "nats" }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -26,5 +27,6 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ . }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/bindplane/templates/service.yaml
+++ b/charts/bindplane/templates/service.yaml
@@ -37,17 +37,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   ports:
-    - port: 4222
-      protocol: TCP
-      targetPort: client
-      name: client
-    - port: 8222
-      protocol: TCP
-      targetPort: http
-      name: http
     - port: 6222
       protocol: TCP
-      targetPort: cluster
+      targetPort: 6222
       name: cluster
   selector:
     app.kubernetes.io/name: {{ include "bindplane.name" . }}

--- a/charts/bindplane/templates/service.yaml
+++ b/charts/bindplane/templates/service.yaml
@@ -22,3 +22,39 @@ spec:
     app.kubernetes.io/instance: {{ .Release.Name }}
   sessionAffinity: None
   type: ClusterIP
+{{- if eq .Values.eventbus.type "nats" }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bindplane.fullname" . }}-nats-headless
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "bindplane.name" . }}
+    app.kubernetes.io/stack: bindplane
+    app.kubernetes.io/component: nats
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  ports:
+    - port: 4222
+      protocol: TCP
+      targetPort: client
+      name: client
+    - port: 8222
+      protocol: TCP
+      targetPort: http
+      name: http
+    - port: 6222
+      protocol: TCP
+      targetPort: cluster
+      name: cluster
+  selector:
+    app.kubernetes.io/name: {{ include "bindplane.name" . }}
+    app.kubernetes.io/stack: bindplane
+    app.kubernetes.io/component: server
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  sessionAffinity: None
+  type: ClusterIP
+  clusterIP: None
+{{- end }}

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -97,9 +97,8 @@ prometheus:
     # -- The Kubernetes storage class to use for the volumeClaimTemplate. If unset, the volume claim will use the cluster's default storage class.
     storageClass: ""
 
-
 eventbus:
-  # The eventbus type to use when BindPlane is deployed with multiple pods (Deployment). Available options include `pubsub`. By default, this option is not required as BindPlane OP operates as a StatefulSet with one pod.
+  # The eventbus type to use when BindPlane is deployed with multiple pods (Deployment). Available options include `pubsub`, `kafka`, `nats`. By default, this option is not required as BindPlane OP operates as a StatefulSet with one pod.
   type: ""
 
   pubsub:
@@ -327,6 +326,9 @@ trace:
     endpoint: ""
     # -- Set to `true` to disable TLS. Set to false if TLS is in use by the OTLP trace receiver.
     insecure: false
+
+# -- The number of replicas to use when BindPlane is deployed as a Deployment. This options is ignored if autoscaling is enabled. When `eventbus.type` is set to `nats`, replica count should be an odd number such as 3 and 5. 
+replicaCount: 1
 
 autoscaling:
   # -- Whether or not autoscaling should be enabled. Requires an eventbus to be configured.


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Added NATS eventbus (this is an alpha feature, and not documented. It is not intended to be consumed by users at this time).

## Testing

Testing is straight forward if you are comfortable with minikube. I tried to include detailed steps.

Setup minikube w/ ingress

```bash
minikube start
minikube addons enable ingress 
```

Update your `/etc/hosts` to include the following:

```
127.0.0.1 local.bindplane.com
```

Make sure you are connected to minikube

```bash
kubectl get node
```

Deploy postgres from my [github gist](https://gist.github.com/jsirianni/daf04c72340dc97aba1eedf01057b17e)

```
kubectl apply -f https://gist.githubusercontent.com/jsirianni/daf04c72340dc97aba1eedf01057b17e/raw/d7edca43cd271f47aec7db4127acecdb86e35151/pg.yaml
```

Create `values.yaml`. Make sure to add your own license to `config.license`.

```yaml
config:
  license: <your license>

  username: user
  password: password
  secret_key: 7F9AF8D8-BED7-45A4-9696-145ED96020C8
  sessions_secret: 7F9AF8D8-BED7-45A4-9696-145ED96020C8
resources:
  requests:
    cpu: 100m
    memory: 200Mi
  limits:
    memory: 200Mi
backend:
  type: postgres
  postgres:
    host: postgres.default.svc.cluster.local
    database: bindplane
    username: root
    password: password
eventbus:
  type: nats
replicaCount: 3
image:
  tag: 1.48.0
ingress:
  enable: true
  host: bindplane.local
  class: nginx
dev:
  collector:
    create: true
```

Deploy with `helm template`

```bash
helm template --values ./values.yaml charts/bindplane | kubectl apply -f -
```

Scale the test agent deployment to five replicas

```bash
kubectl scale deploy/bindplane-test-agent --replicas 5
```

Wait for the pods with k9s

```bash
k9s -n default
```

<img width="1001" alt="Screenshot 2024-03-05 at 3 20 14 PM" src="https://github.com/observIQ/bindplane-op-helm/assets/23043836/aa0d76a8-d911-47e7-8fbc-20b0e60caeae">

Run `minikube tunnel` and provide your password. This command will block, and allow your browser to reach http://bindplane.local/login. Login with `user` / `password`.

Create a config named "test" and perform several rollouts. Make sure "recent telemetry" or "processor preview" is working on various agents. This will prove that the event bus is working.

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
