### PR TITLE
feat(secret): Support reading the license key from secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,11 @@ jobs:
           sleep 30
           kubectl -n ingress-nginx get all
 
+      - name: Create secret
+        run: |
+          kubectl -n default create secret generic bindplane \
+            --from-literal=license=${{ secrets.BINDPLANE_LICENSE }}
+
       - name: Deploy
         run: |
           helm template \

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The secret should have the following keys:
 - `password`: Basic auth password to use for the default admin user
 - `secret_key`: Random UUIDv4 to use for authenticating OpAMP clients
 - `sessions_secret`: Random UUIDv4 used to derive web interface session tokens
+- `license`: Your BindPlane license key
 
 Example: Create secret with `kubectl`:
 
@@ -31,7 +32,8 @@ kubectl -n default create secret generic bindplane \
   --from-literal=username=myuser \
   --from-literal=password=mypassword \
   --from-literal=secret_key=353753ca-ae48-40f9-9588-28cf86430910 \
-  --from-literal=sessions_secret=d9425db6-c4ee-4769-9c1f-a66987679e90
+  --from-literal=sessions_secret=d9425db6-c4ee-4769-9c1f-a66987679e90 \
+  --from-literal=license=your_license_key
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Helm's [documentation](https://helm.sh/docs) to get started.
 
 ### Secrets
 
-The Chart can accept a secret for configuring sensative options. This secret should be managed outside of helm with your preferred secret management solution. Alternatively, you can specify
+The Chart can accept a secret for configuring sensitive options. This secret should be managed outside of helm with your preferred secret management solution. Alternatively, you can specify
 these options using a values file. See the [Chart documentation](./charts/bindplane/README.md).
 
 The secret should have the following keys:

--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an open source observability pipeline.
 type: application
 # The chart's version
-version: 1.2.3
+version: 1.2.4
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.48.0

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 1.2.3](https://img.shields.io/badge/Version-1.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.48.0](https://img.shields.io/badge/AppVersion-1.48.0-informational?style=flat-square)
+![Version: 1.2.4](https://img.shields.io/badge/Version-1.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.48.0](https://img.shields.io/badge/AppVersion-1.48.0-informational?style=flat-square)
 
 BindPlane OP is an open source observability pipeline.
 

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -48,10 +48,10 @@ BindPlane OP is an open source observability pipeline.
 | backend.postgres.username | string | `""` | Username to use when connecting to Postgres. |
 | backend.type | string | `"bbolt"` | Backend to use for persistent storage. Available options are `bbolt`, and `postgres`. |
 | config.accept_eula | bool | `true` | Whether or not to accept the EULA. EULA acceptance is required. See https://observiq.com/legal/eula. |
-| config.license | string | `""` | The license key to use for BindPlane OP. Keep unset to use the free edition. |
+| config.license | string | `""` | The license key to use for BindPlane OP. Overrides `config.secret`. |
 | config.password | string | `""` | Password to use. Overrides `config.secret`. |
 | config.remote_url | string | `""` | URI used by agents to communicate with BindPlane using OpAMP. NOTE: This value is not used in BindPlane OP v1.15.0 and newer.  It will eventually be removed when support for older versions of BindPlane is removed from this chart. |
-| config.secret | string | `"bindplane"` | Name of the Kubernetes secret which contains the `username`, `password`, `secret_key`, and `sessions_secret` configuration options. |
+| config.secret | string | `"bindplane"` | Name of the Kubernetes secret which contains the `username`, `password`, `secret_key`, `sessions_secret`, and `license` configuration options. |
 | config.secret_key | string | `""` | Secret Key to use. Overrides `config.secret`. |
 | config.server_url | string | `""` | URI used by clients to communicate with BindPlane. |
 | config.sessions_secret | string | `""` | Sessions Secret to use. Overrides `config.secret`. |

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -49,6 +49,7 @@ BindPlane OP is an open source observability pipeline.
 | backend.type | string | `"bbolt"` | Backend to use for persistent storage. Available options are `bbolt`, and `postgres`. |
 | config.accept_eula | bool | `true` | Whether or not to accept the EULA. EULA acceptance is required. See https://observiq.com/legal/eula. |
 | config.license | string | `""` | The license key to use for BindPlane OP. Overrides `config.secret`. |
+| config.licenseUseSecret | bool | `false` | When true, the license key will be referenced from the `config.secret` secret. |
 | config.password | string | `""` | Password to use. Overrides `config.secret`. |
 | config.remote_url | string | `""` | URI used by agents to communicate with BindPlane using OpAMP. NOTE: This value is not used in BindPlane OP v1.15.0 and newer.  It will eventually be removed when support for older versions of BindPlane is removed from this chart. |
 | config.secret | string | `"bindplane"` | Name of the Kubernetes secret which contains the `username`, `password`, `secret_key`, `sessions_secret`, and `license` configuration options. |

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -45,10 +45,11 @@ spec:
               value: "true"
             - name: BINDPLANE_TRANSFORM_AGENT_REMOTE_AGENTS
               value: "{{ include "bindplane.fullname" . }}-transform-agent:4568"
-            - name: BINDPLANE_LICENSE
             {{- if .Values.config.license }}
+            - name: BINDPLANE_LICENSE
               value: {{ .Values.config.license }}
-            {{- else }}
+            {{- else if .Values.config.licenseUseSecret }}
+            - name: BINDPLANE_LICENSE
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.config.secret }}

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -48,6 +48,12 @@ spec:
             {{- if .Values.config.license }}
             - name: BINDPLANE_LICENSE
               value: {{ .Values.config.license }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.secret }}
+                  key: license
+                  optional: false
             {{- end}}
             - name: BINDPLANE_ACCEPT_EULA
               value: "{{ .Values.config.accept_eula }}"

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -45,10 +45,10 @@ spec:
               value: "true"
             - name: BINDPLANE_TRANSFORM_AGENT_REMOTE_AGENTS
               value: "{{ include "bindplane.fullname" . }}-transform-agent:4568"
-            {{- if .Values.config.license }}
             - name: BINDPLANE_LICENSE
+            {{- if .Values.config.license }}
               value: {{ .Values.config.license }}
-              {{- else }}
+            {{- else }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.config.secret }}

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -224,8 +224,6 @@ transform_agent:
 # Bindplane configuration options:
 # https://github.com/observIQ/bindplane-op/blob/main/docs/configuration.md
 config:
-  # -- The license key to use for BindPlane OP. Keep unset to use the free edition.
-  license: ""
   # -- Whether or not to accept the EULA. EULA acceptance is required. See https://observiq.com/legal/eula.
   accept_eula: true
   # The URI used by clients to communicate with bindplane-op. Defaults to the
@@ -248,13 +246,14 @@ config:
   #   --from-literal=username=myuser \
   #   --from-literal=password=mypassword \
   #   --from-literal=secret_key=353753ca-ae48-40f9-9588-28cf86430910 \
-  #   --from-literal=sessions_secret=d9425db6-c4ee-4769-9c1f-a66987679e90
-  # -- Name of the Kubernetes secret which contains the `username`, `password`, `secret_key`, and `sessions_secret` configuration options.
+  #   --from-literal=sessions_secret=d9425db6-c4ee-4769-9c1f-a66987679e90 \
+  #   --from-literal=license=your_license_key
+  # -- Name of the Kubernetes secret which contains the `username`, `password`, `secret_key`, `sessions_secret`, and `license` configuration options.
   secret: bindplane
 
   # The following options override values set in the secret. Useful
   # for quick testing where you do not want to be bothered with managing
-  # sensative values outside of helm.
+  # sensitive values outside of helm.
   # -- Username to use. Overrides `config.secret`.
   username: ""
   # -- Password to use. Overrides `config.secret`.
@@ -263,6 +262,8 @@ config:
   secret_key: ""
   # -- Sessions Secret to use. Overrides `config.secret`.
   sessions_secret: ""
+  # -- The license key to use for BindPlane OP. Overrides `config.secret`.
+  license: ""
 
 
 # Pod resource requests and limits can be defined here.

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -264,6 +264,8 @@ config:
   sessions_secret: ""
   # -- The license key to use for BindPlane OP. Overrides `config.secret`.
   license: ""
+  # -- When true, the license key will be referenced from the `config.secret` secret.
+  licenseUseSecret: false
 
 
 # Pod resource requests and limits can be defined here.

--- a/test/cases/all/values.yaml
+++ b/test/cases/all/values.yaml
@@ -6,6 +6,7 @@ config:
   sessions_secret: 4484766F-5016-4077-B8E0-0DE1D637854B
   server_url: http://bindplane.local:3001
   remote_url: ws://bindplane.local:3001
+  licenseUseSecret: true
 
 # All
 enterprise: false

--- a/values/large.yaml
+++ b/values/large.yaml
@@ -47,6 +47,7 @@ config:
   #   --from-literal=username=myuser \
   #   --from-literal=password=mypassword \
   #   --from-literal=secret_key=353753ca-ae48-40f9-9588-28cf86430910 \
-  #   --from-literal=sessions_secret=d9425db6-c4ee-4769-9c1f-a66987679e90
-  # -- Name of the Kubernetes secret which contains the `username`, `password`, `secret_key`, and `sessions_secret` configuration options.
+  #   --from-literal=sessions_secret=d9425db6-c4ee-4769-9c1f-a66987679e90 \
+  #   --from-literal=license=your_license_key
+  # -- Name of the Kubernetes secret which contains the `username`, `password`, `secret_key`, `sessions_secret`, and `license` configuration options.
   secret: bindplane

--- a/values/small.yaml
+++ b/values/small.yaml
@@ -47,6 +47,7 @@ config:
   #   --from-literal=username=myuser \
   #   --from-literal=password=mypassword \
   #   --from-literal=secret_key=353753ca-ae48-40f9-9588-28cf86430910 \
-  #   --from-literal=sessions_secret=d9425db6-c4ee-4769-9c1f-a66987679e90
-  # -- Name of the Kubernetes secret which contains the `username`, `password`, `secret_key`, and `sessions_secret` configuration options.
+  #   --from-literal=sessions_secret=d9425db6-c4ee-4769-9c1f-a66987679e90 \
+  #   --from-literal=license=your_license_key
+  # -- Name of the Kubernetes secret which contains the `username`, `password`, `secret_key`, `sessions_secret`, and `license` configuration options.
   secret: bindplane


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Added a new option, `config.licenseUseSecret`. When true, the license will be read from the "bindplane" secret. This option is only considered if `config.license` is not set. If both options are not set, the license will not be set in the environment (this is the existing behavior).

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
