### PR TITLE
feat: Support arbitrary volumes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           - "default"
           - "image"
           - "ingress"
+          - "volume"
         k8s_version:
           - v1.25.0
           - v1.27.0

--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an open source observability pipeline.
 type: application
 # The chart's version
-version: 1.2.5
+version: 1.3.0
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.48.0

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 1.2.5](https://img.shields.io/badge/Version-1.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.48.0](https://img.shields.io/badge/AppVersion-1.48.0-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.48.0](https://img.shields.io/badge/AppVersion-1.48.0-informational?style=flat-square)
 
 BindPlane OP is an open source observability pipeline.
 
@@ -91,6 +91,8 @@ BindPlane OP is an open source observability pipeline.
 | eventbus.pubsub.projectid | string | `""` |  |
 | eventbus.pubsub.topic | string | `""` |  |
 | eventbus.type | string | `""` |  |
+| extraVolumeMounts | list | `[]` | Optional arbitrary volume mounts to add to the BindPlane pod(s). |
+| extraVolumes | list | `[]` | Optional arbitrary volumes to add to the BindPlane pod(s). |
 | health.livenessProbe | object | `{"httpGet":{"path":"/health","port":"http"}}` | Full configuration for livenessProbe. Supports all options documented here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/. |
 | health.readinessProbe | object | `{"httpGet":{"path":"/health","port":"http"}}` | Full configuration for readinessProbe. Supports all options documented here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/. |
 | health.startupProbe | object | `{"httpGet":{"path":"/health","port":"http"}}` | Full configuration for startupProbe. Supports all options documented here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/. |

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -374,6 +374,9 @@ spec:
               subPath: {{ .Values.prometheus.tls.secret.keySubPath }}
             {{- end }}
             {{- end }}
+            {{- if len .Values.extraVolumeMounts }}
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
           lifecycle:
             preStop:
               exec:
@@ -435,6 +438,9 @@ spec:
             defaultMode: 0400
             secretName: {{ .Values.prometheus.tls.secret.name }}
         {{- end }}
+        {{- end }}
+        {{- if len .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
         {{- end }}
   {{- if eq (include "bindplane.deployment_type" .) "StatefulSet" }}
   volumeClaimTemplates:

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -410,3 +410,9 @@ dev:
       # Generally this should match the version found
       # here https://github.com/observIQ/bindplane-op-enterprise/blob/release/v1.38.0/PROMETHEUS_VERSION
       tag: v2.47.2
+
+# -- Optional arbitrary volumes to add to the BindPlane pod(s).
+extraVolumes: []
+
+# -- Optional arbitrary volume mounts to add to the BindPlane pod(s).
+extraVolumeMounts: []

--- a/test/cases/volume/values.yaml
+++ b/test/cases/volume/values.yaml
@@ -1,0 +1,15 @@
+# Required options
+config:
+  username: bpuser
+  password: bppass
+  secret_key: 12D8FB6E-1532-4A4C-97AF-95A430BE5E6E
+  sessions_secret: 4484766F-5016-4077-B8E0-0DE1D637854B
+
+extraVolumes:
+  - name: cache-volume
+    emptyDir:
+      sizeLimit: 500Mi
+
+extraVolumeMounts:
+  - mountPath: /tmp/cache
+    name: cache-volume


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Users can define custom volume and volume mount configurations. This is useful for mounting secret provider class secrets.

I added a test cases that drops in an emptyDir volume.

```yaml
config:
  username: bpuser
  password: bppass
  secret_key: 12D8FB6E-1532-4A4C-97AF-95A430BE5E6E
  sessions_secret: 4484766F-5016-4077-B8E0-0DE1D637854B

extraVolumes:
  - name: cache-volume
    emptyDir:
      sizeLimit: 500Mi

extraVolumeMounts:
  - mountPath: /tmp/cache
    name: cache-volume
```

The resulting manifest runs great. It has the correct indentation/formatting.

```yaml
...
          volumeMounts:
            - mountPath: /data
              name: release-name-bindplane-data
            - mountPath: /tmp/cache
              name: cache-volume
...
      volumes:
        - emptyDir:
            sizeLimit: 500Mi
          name: cache-volume
...
```

If I exec into the container, I can create files. The container filesystem is read only, but we can write to the empty dir volume at `/tmp/cache`.

```
~ $ touch /tmp/test
touch: /tmp/test: Read-only file system
~ $ touch /tmp/cache/test
~ $ echo $?
0
```

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
