### PR TITLE
feat(prometheus): Support setting prometheus image name

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an open source observability pipeline.
 type: application
 # The chart's version
-version: 1.3.1
+version: 1.3.2
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.49.0

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.49.0](https://img.shields.io/badge/AppVersion-1.49.0-informational?style=flat-square)
+![Version: 1.3.2](https://img.shields.io/badge/Version-1.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.49.0](https://img.shields.io/badge/AppVersion-1.49.0-informational?style=flat-square)
 
 BindPlane OP is an open source observability pipeline.
 
@@ -111,6 +111,7 @@ BindPlane OP is an open source observability pipeline.
 | prometheus.auth.username | string | `""` | Prometheus basic authentication username. |
 | prometheus.enableSideCar | bool | `false` | When enabled, the Prometheus measurements backend will be deployed as a sidecar container. This option is only valid when BindPlane is running as a single node statefulset. |
 | prometheus.host | string | `""` | The Prometheus hostname or IP address used for querying and writing metrics. Defaults to the service name of the Prometheus StatefulSet deployed by this chart. |
+| prometheus.image.name | string | `"ghcr.io/observiq/bindplane-prometheus"` | Image name to be used. Defaults to `ghcr.io/observiq/bindplane-prometheus`. NOTE: The image tag is derived from the BindPlane server tag. |
 | prometheus.port | int | `9090` | The Prometheus TCP port used for querying and writing metrics. |
 | prometheus.queryPathPrefix | string | `""` | Optional Prometheus query path prefix. Useful when overriding the query endpoints when using systems such as Mimir. |
 | prometheus.remote | bool | `false` | When true, the chart will not deploy Prometheus. Instead, the user should provide a Prometheus instance to use. |

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -384,7 +384,7 @@ spec:
         {{- if eq (include "bindplane.deployment_type" .) "StatefulSet" }}
         {{- if and (.Values.prometheus.enableSideCar) (eq .Values.prometheus.remote false)}}
         - name: prometheus
-          image: ghcr.io/observiq/bindplane-prometheus:{{ include "bindplane.tag" . }}
+          image: {{ .Values.prometheus.image.name }}:{{ include "bindplane.tag" . }}
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true

--- a/charts/bindplane/templates/prometheus.yaml
+++ b/charts/bindplane/templates/prometheus.yaml
@@ -32,7 +32,7 @@ spec:
         fsGroup: 65534
       containers:
         - name: prometheus
-          image: ghcr.io/observiq/bindplane-prometheus:{{ include "bindplane.tag" . }}
+          image: {{ .Values.prometheus.image.name }}:{{ include "bindplane.tag" . }}
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -30,6 +30,9 @@ backend:
 # TODO(jsirianni): Support authentication and TLS.
 # This is undocumented for now, as Prometheus support has not been released.
 prometheus:
+  image:
+    # -- Image name to be used. Defaults to `ghcr.io/observiq/bindplane-prometheus`. NOTE: The image tag is derived from the BindPlane server tag.
+    name: "ghcr.io/observiq/bindplane-prometheus"
   # -- When true, the chart will not deploy Prometheus. Instead, the user should provide a Prometheus instance to use.
   remote: false
   # -- When enabled, the Prometheus measurements backend will be deployed as a sidecar container. This option is only valid when BindPlane is running as a single node statefulset.


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Instead of hardcoding `ghcr.io/observiq/bindplane-prometheus` for the Prometheus sidecar and statefulset, it is now an option at `prometheus.image.name` defaulting to `ghcr.io/observiq/bindplane-prometheus`. 

## Testing

Works great w/ the following:

```bash
minikube start
helm template --values test/cases/default/values.yaml charts/bindplane | k apply -f -
```

Wait for the images to come up, and then check to make sure they are running:

```bash
$ kubectl get pod

NAME                                                      READY   STATUS    RESTARTS   AGE
release-name-bindplane-0                                  1/1     Running   0          86s
release-name-bindplane-prometheus-0                       1/1     Running   0          2m7s
release-name-bindplane-transform-agent-59d7657d8f-6rrxr   1/1     Running   0          2m7s
```

You can inspect the pod's image if you want:

```bash
kubectl get pod release-name-bindplane-prometheus-0 -o json | jq '.spec.containers[0].image'
```
```
"ghcr.io/observiq/bindplane-prometheus:1.49.0"
```

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
