### PR TITLE
feat: Support extra labels for bindplane and prometheus pods

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an open source observability pipeline.
 type: application
 # The chart's version
-version: 1.3.2
+version: 1.4.0
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.49.0

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 1.3.2](https://img.shields.io/badge/Version-1.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.49.0](https://img.shields.io/badge/AppVersion-1.49.0-informational?style=flat-square)
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.49.0](https://img.shields.io/badge/AppVersion-1.49.0-informational?style=flat-square)
 
 BindPlane OP is an open source observability pipeline.
 
@@ -91,6 +91,7 @@ BindPlane OP is an open source observability pipeline.
 | eventbus.pubsub.projectid | string | `""` |  |
 | eventbus.pubsub.topic | string | `""` |  |
 | eventbus.type | string | `""` |  |
+| extraPodLabels | object | `{}` | Optional arbitrary labels to add to the BindPlane pod(s). |
 | extraVolumeMounts | list | `[]` | Optional arbitrary volume mounts to add to the BindPlane pod(s). |
 | extraVolumes | list | `[]` | Optional arbitrary volumes to add to the BindPlane pod(s). |
 | health.livenessProbe | object | `{"httpGet":{"path":"/health","port":"http"}}` | Full configuration for livenessProbe. Supports all options documented here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/. |
@@ -110,6 +111,7 @@ BindPlane OP is an open source observability pipeline.
 | prometheus.auth.type | string | `"none"` | Prometheus authentication. Supported options include `none` and `basic`. |
 | prometheus.auth.username | string | `""` | Prometheus basic authentication username. |
 | prometheus.enableSideCar | bool | `false` | When enabled, the Prometheus measurements backend will be deployed as a sidecar container. This option is only valid when BindPlane is running as a single node statefulset. |
+| prometheus.extraPodLabels | object | `{}` | Optional arbitrary labels to add to the Prometheus pod. This option is only used when Prometheus is running as a StatefulSet managed by the chart (The default mode). |
 | prometheus.host | string | `""` | The Prometheus hostname or IP address used for querying and writing metrics. Defaults to the service name of the Prometheus StatefulSet deployed by this chart. |
 | prometheus.image.name | string | `"ghcr.io/observiq/bindplane-prometheus"` | Image name to be used. Defaults to `ghcr.io/observiq/bindplane-prometheus`. NOTE: The image tag is derived from the BindPlane server tag. |
 | prometheus.port | int | `9090` | The Prometheus TCP port used for querying and writing metrics. |

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -27,6 +27,9 @@ spec:
         app.kubernetes.io/stack: bindplane
         app.kubernetes.io/component: server
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- if len .Values.extraPodLabels }}
+        {{- toYaml .Values.extraPodLabels | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "bindplane.fullname" . }}
       {{- with .Values.podSecurityContext }}

--- a/charts/bindplane/templates/prometheus.yaml
+++ b/charts/bindplane/templates/prometheus.yaml
@@ -27,6 +27,9 @@ spec:
         app.kubernetes.io/stack: bindplane
         app.kubernetes.io/component: prometheus
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- if len .Values.prometheus.extraPodLabels }}
+        {{- toYaml .Values.prometheus.extraPodLabels | nindent 8 }}
+        {{- end }}
     spec:
       securityContext:
         fsGroup: 65534

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -99,6 +99,8 @@ prometheus:
     volumeSize: 10Gi
     # -- The Kubernetes storage class to use for the volumeClaimTemplate. If unset, the volume claim will use the cluster's default storage class.
     storageClass: ""
+  # -- Optional arbitrary labels to add to the Prometheus pod. This option is only used when Prometheus is running as a StatefulSet managed by the chart (The default mode).
+  extraPodLabels: {}
 
 
 eventbus:
@@ -419,3 +421,6 @@ extraVolumes: []
 
 # -- Optional arbitrary volume mounts to add to the BindPlane pod(s).
 extraVolumeMounts: []
+
+# -- Optional arbitrary labels to add to the BindPlane pod(s).
+extraPodLabels: {}

--- a/test/cases/labels/values.yaml
+++ b/test/cases/labels/values.yaml
@@ -1,0 +1,15 @@
+# Required options
+config:
+  username: bpuser
+  password: bppass
+  secret_key: 12D8FB6E-1532-4A4C-97AF-95A430BE5E6E
+  sessions_secret: 4484766F-5016-4077-B8E0-0DE1D637854B
+
+extraPodLabels:
+  extraKey: extraValue
+  extraKey2: extraValue2
+
+prometheus:
+  extraPodLabels:
+    extraKeyProm: extraValueProm
+    extraKeyProm2: extraValueProm2


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Added two new options
- `extraPodLabels`
- `prometheus.extraPodLabels`

These will add abitrary labels to the StatefulSet / Deployment's pod template (`spec.template.metadata.labels`, AKA pod labels).

## Testing

```bash
minikube start
helm template charts/bindplane --values test/cases/labels/values.yaml | kubectl apply -f -
```

Once deployed, you can do a `get pod <name` on the bindplane and Prometheus pods, parse with jq.

```
➜  bindplane-op-helm git:(feat/extra-pod-labels) ✗ kubectl get pod release-name-bindplane-0 -o json | jq '.metadata.labels'
{
  "app.kubernetes.io/component": "server",
  "app.kubernetes.io/instance": "release-name",
  "app.kubernetes.io/name": "bindplane",
  "app.kubernetes.io/stack": "bindplane",
  "controller-revision-hash": "release-name-bindplane-69d7695dff",
  "extraKey": "extraValue",
  "extraKey2": "extraValue2",
  "statefulset.kubernetes.io/pod-name": "release-name-bindplane-0"
}

```
```
➜  bindplane-op-helm git:(feat/extra-pod-labels) ✗ kubectl get pod release-name-bindplane-prometheus-0 -o json | jq '.metadata.labels'
{
  "app.kubernetes.io/component": "prometheus",
  "app.kubernetes.io/instance": "release-name",
  "app.kubernetes.io/name": "bindplane",
  "app.kubernetes.io/stack": "bindplane",
  "controller-revision-hash": "release-name-bindplane-prometheus-564456c78b",
  "extraKeyProm": "extraValueProm",
  "extraKeyProm2": "extraValueProm2",
  "statefulset.kubernetes.io/pod-name": "release-name-bindplane-prometheus-0"
}
```

The labels defined in the values file appear on the pod as expected.

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
