### PR TITLE
feat: Add jobs pod when using high availabily deployment

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an observability pipeline.
 type: application
 # The chart's version
-version: 1.7.4
+version: 1.8.0
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.52.0

--- a/charts/bindplane/templates/bindplane-jobs.yaml
+++ b/charts/bindplane/templates/bindplane-jobs.yaml
@@ -271,9 +271,7 @@ spec:
             - name: BINDPLANE_PROMETHEUS_ENABLE_REMOTE
               value: "true"
             - name: BINDPLANE_PROMETHEUS_HOST
-              {{- if .Values.prometheus.enableSideCar }}
-              value: localhost
-              {{- else if .Values.prometheus.remote }}
+              {{- if .Values.prometheus.remote }}
               value: {{ .Values.prometheus.host }}
               {{- else }}
               value: {{ include "bindplane.fullname" . }}-prometheus
@@ -401,30 +399,6 @@ spec:
             preStop:
               exec:
                 command: ["sh", "-c", "sleep 5",]
-        {{- if eq (include "bindplane.deployment_type" .) "StatefulSet" }}
-        {{- if and (.Values.prometheus.enableSideCar) (eq .Values.prometheus.remote false)}}
-        - name: prometheus
-          image: {{ .Values.prometheus.image.name }}:{{ include "bindplane.tag" . }}
-          imagePullPolicy: IfNotPresent
-          securityContext:
-            runAsNonRoot: true
-            readOnlyRootFilesystem: true
-            runAsUser: 65534
-            capabilities:
-              drop: ["ALL"]
-          ports:
-            - name: http
-              containerPort: 9090
-              protocol: TCP
-          {{- with .Values.prometheus.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          volumeMounts:
-            - mountPath: /prometheus
-              name: {{ include "bindplane.fullname" . }}-prometheus-data
-        {{- end }}
-        {{- end }}
       terminationGracePeriodSeconds: 60
       volumes:
         {{- if eq .Values.eventbus.type "pubsub" }}
@@ -462,45 +436,4 @@ spec:
         {{- if len .Values.extraVolumes }}
         {{- toYaml .Values.extraVolumes | nindent 8 }}
         {{- end }}
-  {{- if eq (include "bindplane.deployment_type" .) "StatefulSet" }}
-  volumeClaimTemplates:
-    {{- if eq .Values.backend.type "bbolt" }}
-    - metadata:
-        name: {{ include "bindplane.fullname" . }}-data
-        labels:
-          app.kubernetes.io/name: {{ include "bindplane.name" . }}
-          app.kubernetes.io/stack: bindplane
-          app.kubernetes.io/component: jobs
-          app.kubernetes.io/instance: {{ .Release.Name }}
-          app.kubernetes.io/managed-by: {{ .Release.Service }}
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: {{ .Values.backend.bbolt.volumeSize }}
-        {{- if .Values.backend.bbolt.storageClass }}
-        storageClassName: {{ .Values.backend.bbolt.storageClass }}
-        {{- end }}
-    {{- end }}
-    {{- if and (.Values.prometheus.enableSideCar) (eq .Values.prometheus.remote false)}}
-    - metadata:
-        name: {{ include "bindplane.fullname" . }}-prometheus-data
-        labels:
-          app.kubernetes.io/name: {{ include "bindplane.name" . }}
-          app.kubernetes.io/stack: bindplane
-          app.kubernetes.io/component: jobs
-          app.kubernetes.io/instance: {{ .Release.Name }}
-          app.kubernetes.io/managed-by: {{ .Release.Service }}
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: {{ .Values.prometheus.storage.volumeSize }}
-        {{- if .Values.prometheus.storage.storageClass }}
-        storageClassName: {{ .Values.prometheus.storage.storageClass }}
-        {{- end }}
-    {{- end }}
-  {{- end }}
 {{- end }}

--- a/charts/bindplane/templates/bindplane-jobs.yaml
+++ b/charts/bindplane/templates/bindplane-jobs.yaml
@@ -1,40 +1,29 @@
+{{- if eq (include "bindplane.deployment_type" .) "Deployment" }}
 apiVersion: apps/v1
-kind: {{ include "bindplane.deployment_type" . }}
+kind: Deployment
 metadata:
-  name: {{ include "bindplane.fullname" . }}
+  name: {{ include "bindplane.fullname" . }}-jobs
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "bindplane.name" . }}
     app.kubernetes.io/stack: bindplane
-    app.kubernetes.io/component: server
+    app.kubernetes.io/component: jobs
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  {{- if gt (int .Values.replicas) 0 }}
-  replicas: {{ .Values.replicas }}
-  {{- end }}
-  {{- if eq (include "bindplane.deployment_type" .) "StatefulSet" }}
-  serviceName: {{ include "bindplane.fullname" . }}
-  {{- else }}
-  minReadySeconds: 20
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-    type: RollingUpdate
-  {{- end }}
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "bindplane.name" . }}
       app.kubernetes.io/stack: bindplane
-      app.kubernetes.io/component: server
+      app.kubernetes.io/component: jobs
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
         app.kubernetes.io/name: {{ include "bindplane.name" . }}
         app.kubernetes.io/stack: bindplane
-        app.kubernetes.io/component: server
+        app.kubernetes.io/component: jobs
         app.kubernetes.io/instance: {{ .Release.Name }}
         {{- if len .Values.extraPodLabels }}
         {{- toYaml .Values.extraPodLabels | nindent 8 }}
@@ -58,11 +47,7 @@ spec:
               name: http
           env:
             - name: BINDPLANE_MODE
-              {{- if eq (include "bindplane.deployment_type" .) "StatefulSet" }}
               value: all
-              {{- else }}
-              value: node
-              {{- end }}
             - name: BINDPLANE_ANALYTICS_DISABLED
               value: "{{ .Values.config.analytics.disable }}"
             - name: BINDPLANE_TRANSFORM_AGENT_ENABLE_REMOTE
@@ -173,14 +158,6 @@ spec:
             {{- if .Values.eventbus.pubsub.credentials.secret }}
             - name: BINDPLANE_GOOGLE_PUB_SUB_CREDENTIALS_FILE
               value: /credentials.json
-            {{- end }}
-            {{- if .Values.eventbus.pubsub.endpoint }}
-            - name: BINDPLANE_GOOGLE_PUB_SUB_ENDPOINT
-              value: {{ .Values.eventbus.pubsub.endpoint }}
-            {{- end }}
-            {{- if .Values.eventbus.pubsub.insecure }}
-            - name: BINDPLANE_GOOGLE_PUB_SUB_INSECURE
-              value: "{{ .Values.eventbus.pubsub.insecure }}"
             {{- end }}
             {{- end }}
             {{- if eq .Values.eventbus.type "kafka" }}
@@ -344,7 +321,7 @@ spec:
             {{- if len .Values.extraEnv }}
             {{- toYaml .Values.extraEnv | nindent 12 }}
             {{- end }}
-          {{- with .Values.resources }}
+          {{- with .Values.jobs.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -493,7 +470,7 @@ spec:
         labels:
           app.kubernetes.io/name: {{ include "bindplane.name" . }}
           app.kubernetes.io/stack: bindplane
-          app.kubernetes.io/component: server
+          app.kubernetes.io/component: jobs
           app.kubernetes.io/instance: {{ .Release.Name }}
           app.kubernetes.io/managed-by: {{ .Release.Service }}
       spec:
@@ -512,7 +489,7 @@ spec:
         labels:
           app.kubernetes.io/name: {{ include "bindplane.name" . }}
           app.kubernetes.io/stack: bindplane
-          app.kubernetes.io/component: server
+          app.kubernetes.io/component: jobs
           app.kubernetes.io/instance: {{ .Release.Name }}
           app.kubernetes.io/managed-by: {{ .Release.Service }}
       spec:
@@ -526,3 +503,4 @@ spec:
         {{- end }}
     {{- end }}
   {{- end }}
+{{- end }}

--- a/charts/bindplane/templates/bindplane-jobs.yaml
+++ b/charts/bindplane/templates/bindplane-jobs.yaml
@@ -159,6 +159,14 @@ spec:
             - name: BINDPLANE_GOOGLE_PUB_SUB_CREDENTIALS_FILE
               value: /credentials.json
             {{- end }}
+            {{- if .Values.eventbus.pubsub.endpoint }}
+            - name: BINDPLANE_GOOGLE_PUB_SUB_ENDPOINT
+              value: {{ .Values.eventbus.pubsub.endpoint }}
+            {{- end }}
+            {{- if .Values.eventbus.pubsub.insecure }}
+            - name: BINDPLANE_GOOGLE_PUB_SUB_INSECURE
+              value: "{{ .Values.eventbus.pubsub.insecure }}"
+            {{- end }}
             {{- end }}
             {{- if eq .Values.eventbus.type "kafka" }}
             - name: BINDPLANE_EVENT_BUS_TYPE

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -300,6 +300,20 @@ resources:
     # Disable cpu limit by default, for burstable qos class
     # cpu: 1000m
 
+# Configuration for the jobs pod
+jobs:
+  resources:
+    requests:
+      # -- Memory request.
+      memory: 1000Mi
+      # -- CPU request.
+      cpu: 1000m
+    limits:
+      # -- Memory limit.
+      memory: 1000Mi
+      # Disable cpu limit by default, for burstable qos class
+      # cpu: 1000m
+
 health:
   # -- Full configuration for startupProbe. Supports all options documented here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/.
   startupProbe:

--- a/test/cases/pubsub/values.yaml
+++ b/test/cases/pubsub/values.yaml
@@ -41,3 +41,12 @@ resources:
   limits:
     memory: 100Mi
     cpu: 100m
+
+jobs:
+  resources:
+    requests:
+      memory: 100Mi
+      cpu: 100m
+    limits:
+      memory: 100Mi
+      cpu: 100m


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Copied `bindplane.yaml` to `bindplane-jobs.yaml`. The new `jobs` deployment will deploy when the deployment type is "Deployment" (High availability).

Currently, jobs has the similar configuration as the main bindplane deployment. Notable changes:
- `BINDPLANE_MODE` is `all`
- Component label has value `jobs`
  - This will keep the jobs pod out of ingress
- Has its own resource request and limit configuration

## TODO

I think in the future we can refactor both deployments so they share more configuration. Specifically, environment variables. I would like to get more robust testing in place before making such a large change.

## Testing

The jobs pod should only deploy when using postgres. When postgres is configured, the deployment type will be `Deployment`. When using bbolt, deployment type will be `StatefulSet`.

### Bbolt

When testing w/ bbolt, the jobs pod is not deployed and the statefulset has `mode: all`.

```
NAME                                                      READY   STATUS    RESTARTS  
release-name-bindplane-0                                  1/1     Running   0        
release-name-bindplane-prometheus-0                       1/1     Running   0       
release-name-bindplane-transform-agent-59d7657d8f-k4jjv   1/1     Running   0        
```

```bash
$ kubectl exec sts/release-name-bindplane -- env | grep BINDPLANE_MODE

BINDPLANE_MODE=all
```

### Postgres

When using Postgres, BindPlane is deployed as a multi pod Deployment along with a single pod "jobs" Deployment. The main Deployment has `mode: node` and the single jobs pod has `mode: all`. Also note that the `jobs` pod is not present in the main bindplane clusterIP service, meaning agents and UI will not connect to it. Its only purpose is to handle periodic jobs.

I created the license secret with:
```bash
kubectl create secret generic bindplane \
  --from-literal=license=$BINDPLANE_LICENSE
```

I deployed the [pubsub and postgres helpers](https://github.com/observIQ/bindplane-op-helm/tree/jobs/test/helper) and used the values file at [test/cases/pubsub](https://github.com/observIQ/bindplane-op-helm/blob/jobs/test/cases/pubsub/values.yaml).

```
NAME                                                      READY   STATUS    RESTARTS      AGE
release-name-bindplane-dd8cd779c-krg95                    1/1     Running   2 (55s ago)  
release-name-bindplane-dd8cd779c-plkw6                    1/1     Running   2 (56s ago)  
release-name-bindplane-dd8cd779c-v8b4j                    1/1     Running   2 (55s ago)  
release-name-bindplane-jobs-56d9b85479-8988g              1/1     Running   0             
release-name-bindplane-prometheus-0                       1/1     Running   0            
release-name-bindplane-transform-agent-75769c65d8-ssl7g   1/1     Running   0            
```

The bindplane pods restarted a couple times, waiting for the jobs pod to handle configuring the database for initial deployment.

Once deployed, the main deployment has `mode: node`

```bash
$ kubectl exec deploy/release-name-bindplane -- env | grep BINDPLANE_MODE

BINDPLANE_MODE=node
```

The jobs deployment has `mode: all`.

```bash
$ kubectl exec deploy/release-name-bindplane-jobs -- env | grep BINDPLANE_MODE

BINDPLANE_MODE=all
```

The clusterIP service does not match the job pod's ip address, meaning it will never route incoming requests to it. This is desired to keep its resource consumption low.

```
NAME                                                                                    IP                      
release-name-bindplane-dd8cd779c-krg95                   10.244.0.18   
release-name-bindplane-dd8cd779c-plkw6                   10.244.0.15  
release-name-bindplane-dd8cd779c-v8b4j                    10.244.0.16   
release-name-bindplane-jobs-56d9b85479-8988g       10.244.0.17   
release-name-bindplane-prometheus-0                         10.244.0.14  
```
```bash
$ kubectl describe svc release-name-bindplane | grep Endpoints

Endpoints:         10.244.0.15:3001,10.244.0.16:3001,10.244.0.18:3001
```

The UI can be accessed by port forwarding to the service.

```bash
kubectl port-forward service/release-name-bindplane 3011:3001
```

http://localhost:3011

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
