### PR TITLE
feat(postgres): Support TLS ca and client keypair as a secret

### DIFF
--- a/.github/scripts/tls.sh
+++ b/.github/scripts/tls.sh
@@ -5,7 +5,6 @@ set -e
 curl -L -o step-cli_amd64.deb https://github.com/smallstep/cli/releases/download/v0.26.1/step-cli_0.26.1_amd64.deb
 sudo apt-get install -y -qq -f ./step-cli_amd64.deb
 
-
 step certificate create \
   ca.ldap.example.com \
     ca.crt ca.key \
@@ -14,6 +13,8 @@ step certificate create \
     --insecure \
     --not-after=87600h
 
+# Can be used for server and client
+# despite the name being "client".
 step certificate create \
     'ldap.example.com' \
     client.crt client.key \
@@ -29,7 +30,45 @@ kubectl create secret generic ldap-tls \
     --from-file client.crt \
     --from-file client.key
 
+rm -f ca.crt ca.key client.crt client.key
+
+step certificate create \
+  postgres.svc.cluster.local \
+    ca.crt ca.key \
+    --profile root-ca \
+    --no-password \
+    --insecure \
+    --not-after=87600h
+
+step certificate create \
+    'postgres' \
+    client.crt client.key \
+    --profile leaf \
+    --not-after 2160h \
+    --no-password \
+    --insecure \
+    --ca ca.crt \
+    --ca-key ca.key
+
+step certificate create \
+    'postgres.postgres.svc.cluster.local' \
+    server.crt server.key \
+    --profile leaf \
+    --not-after 2160h \
+    --no-password \
+    --insecure \
+    --ca ca.crt \
+    --ca-key ca.key
+
 kubectl create secret generic postgres-tls \
     --from-file ca.crt \
     --from-file client.crt \
     --from-file client.key
+
+kubectl create namespace postgres
+
+kubectl create secret generic postgres-tls \
+    -n postgres \
+    --from-file ca.crt \
+    --from-file server.crt \
+    --from-file server.key

--- a/.github/scripts/tls.sh
+++ b/.github/scripts/tls.sh
@@ -65,7 +65,7 @@ kubectl create secret generic postgres-tls \
     --from-file client.crt \
     --from-file client.key
 
-kubectl create namespace postgres
+kubectl create namespace postgres || true
 
 kubectl create secret generic postgres-tls \
     -n postgres \

--- a/.github/scripts/tls.sh
+++ b/.github/scripts/tls.sh
@@ -28,3 +28,8 @@ kubectl create secret generic ldap-tls \
     --from-file ca.crt \
     --from-file client.crt \
     --from-file client.key
+
+kubectl create secret generic postgres-tls \
+    --from-file ca.crt \
+    --from-file client.crt \
+    --from-file client.key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,8 @@ jobs:
       - name: Deploy PubSub Emulator
         run: kubectl apply -f test/helper/pubsub/pubsub.yaml
 
-      - name: Deploy LDAP Certificate
-        run: .github/scripts/ldap.sh
+      - name: Deploy Certificate
+        run: .github/scripts/tls.sh
 
       - name: Wait For Ingress Pods
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           - "ingress"
           - "volume"
           - "pubsub"
+          - "postgres"
         k8s_version:
           - v1.25.0
           - v1.27.0

--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an observability pipeline.
 type: application
 # The chart's version
-version: 1.10.4
+version: 1.11.0
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.56.0

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -47,7 +47,11 @@ BindPlane OP is an observability pipeline.
 | backend.postgres.maxConnections | int | `100` | Max number of connections to use when communicating with Postgres. |
 | backend.postgres.password | string | `""` | Password for the username used to connect to Postgres. |
 | backend.postgres.port | int | `5432` | TCP port used to connect to Postgres. |
-| backend.postgres.sslmode | string | `"disable"` | SSL mode to use when connecting to Postgres over TLS. See the [postgres ssl documentation](https://jdbc.postgresql.org/documentation/ssl/) for valid options. |
+| backend.postgres.sslmode | string | `"disable"` | SSL mode to use when connecting to Postgres over TLS. Supported options include "disable", "require", "verify-ca", "verify-full". See the [postgres ssl documentation](https://jdbc.postgresql.org/documentation/ssl/) for more information. |
+| backend.postgres.sslsecret.name | string | `"bindplane-postgres-tls"` | Name of the secret that contains the Postgres TLS certificate(s). When SSL mode is set to `verify-ca` or `verify-full`, this secret will be used to mount certificates into the BindPlane container. |
+| backend.postgres.sslsecret.sslcertSubPath | string | `""` | Path to the client certificate used to authenticate with the Postgres server, when mutual TLS is required. |
+| backend.postgres.sslsecret.sslkeySubPath | string | `""` | Path to the client private key used to authenticate with the Postgres server, when mutual TLS is required. |
+| backend.postgres.sslsecret.sslrootcertSubPath | string | `""` | Path to the CA certificate used to verify the Postgres server's certificate. |
 | backend.postgres.username | string | `""` | Username to use when connecting to Postgres. |
 | backend.type | string | `"bbolt"` | Backend to use for persistent storage. Available options are `bbolt`, and `postgres`. |
 | config.accept_eula | bool | `true` | Whether or not to accept the EULA. EULA acceptance is required. See https://observiq.com/legal/eula. |

--- a/charts/bindplane/templates/bindplane-jobs.yaml
+++ b/charts/bindplane/templates/bindplane-jobs.yaml
@@ -134,6 +134,16 @@ spec:
               value: {{ .Values.backend.postgres.database }}
             - name: BINDPLANE_POSTGRES_SSL_MODE
               value: {{ .Values.backend.postgres.sslmode }}
+            {{- if .Values.backend.postgres.sslsecret.sslrootcertSubPath }}
+            - name: BINDPLANE_POSTGRES_SSL_ROOT_CERT
+              value: /postgres-ca.crt
+            {{- end }}
+            {{- if .Values.backend.postgres.sslsecret.sslcertSubPath }}
+            - name: BINDPLANE_POSTGRES_SSL_CERT
+              value: /postgres-client.crt
+            - name: BINDPLANE_POSTGRES_SSL_KEY
+              value: /postgres-client.key
+            {{- end }}
             - name: BINDPLANE_POSTGRES_MAX_CONNECTIONS
               value: "{{ .Values.backend.postgres.maxConnections }}"
             {{- else }}
@@ -408,6 +418,21 @@ spec:
               subPath: {{ .Values.prometheus.tls.secret.keySubPath }}
             {{- end }}
             {{- end }}
+            {{- if .Values.backend.postgres.sslsecret.name }}
+            {{- if .Values.backend.postgres.sslsecret.sslrootcertSubPath }}
+            - mountPath: /postgres-ca.crt
+              name: {{ .Values.backend.postgres.sslsecret.name }}
+              subPath: {{ .Values.backend.postgres.sslsecret.sslrootcertSubPath }}
+            {{- end }}
+            {{- if .Values.backend.postgres.sslsecret.sslcertSubPath }}
+            - mountPath: /postgres-client.crt
+              name: {{ .Values.backend.postgres.sslsecret.name }}
+              subPath: {{ .Values.backend.postgres.sslsecret.sslcertSubPath }}
+            - mountPath: /postgres-client.key
+              name: {{ .Values.backend.postgres.sslsecret.name }}
+              subPath: {{ .Values.backend.postgres.sslsecret.sslkeySubPath }}
+            {{- end }}
+            {{- end }}
             {{- if len .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
@@ -454,6 +479,12 @@ spec:
             defaultMode: 0400
             secretName: {{ .Values.prometheus.tls.secret.name }}
         {{- end }}
+        {{- end }}
+        {{- if .Values.backend.postgres.sslsecret.name }}
+        - name: {{ .Values.backend.postgres.sslsecret.name }}
+          secret:
+            defaultMode: 0400
+            secretName: {{ .Values.backend.postgres.sslsecret.name }}
         {{- end }}
         {{- if len .Values.extraVolumes }}
         {{- toYaml .Values.extraVolumes | nindent 8 }}

--- a/charts/bindplane/templates/bindplane-jobs.yaml
+++ b/charts/bindplane/templates/bindplane-jobs.yaml
@@ -38,6 +38,31 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.backend.postgres.sslsecret.name }}
+      initContainers:
+        - name: postgres-tls
+          image: busybox
+          command:
+          - sh
+          - -c
+          - /bin/chmod 0400 /postgres-ca.crt /postgres-client.crt /postgres-client.key || true
+          volumeMounts:
+            {{- if .Values.backend.postgres.sslsecret.name }}
+            {{- if .Values.backend.postgres.sslsecret.sslrootcertSubPath }}
+            - mountPath: /postgres-ca.crt
+              name: {{ .Values.backend.postgres.sslsecret.name }}
+              subPath: {{ .Values.backend.postgres.sslsecret.sslrootcertSubPath }}
+            {{- end }}
+            {{- if .Values.backend.postgres.sslsecret.sslcertSubPath }}
+            - mountPath: /postgres-client.crt
+              name: {{ .Values.backend.postgres.sslsecret.name }}
+              subPath: {{ .Values.backend.postgres.sslsecret.sslcertSubPath }}
+            - mountPath: /postgres-client.key
+              name: {{ .Values.backend.postgres.sslsecret.name }}
+              subPath: {{ .Values.backend.postgres.sslsecret.sslkeySubPath }}
+            {{- end }}
+            {{- end }}
+      {{- end }}
       containers:
         - name: server
           image: {{ include "bindplane.image" . }}:{{ include "bindplane.tag" . }}

--- a/charts/bindplane/templates/bindplane-jobs.yaml
+++ b/charts/bindplane/templates/bindplane-jobs.yaml
@@ -45,22 +45,25 @@ spec:
           command:
           - sh
           - -c
-          - /bin/chmod 0400 /postgres-ca.crt /postgres-client.crt /postgres-client.key || true
+          - /bin/sh /init.sh
           volumeMounts:
-            {{- if .Values.backend.postgres.sslsecret.name }}
+            - name: postgres-tls-init
+              mountPath: /init.sh
+              subPath: init.sh
+            - mountPath: /postgres-tls
+              name: postgres-tls-dir
             {{- if .Values.backend.postgres.sslsecret.sslrootcertSubPath }}
-            - mountPath: /postgres-ca.crt
+            - mountPath: /ca.crt
               name: {{ .Values.backend.postgres.sslsecret.name }}
               subPath: {{ .Values.backend.postgres.sslsecret.sslrootcertSubPath }}
             {{- end }}
             {{- if .Values.backend.postgres.sslsecret.sslcertSubPath }}
-            - mountPath: /postgres-client.crt
+            - mountPath: /client.crt
               name: {{ .Values.backend.postgres.sslsecret.name }}
               subPath: {{ .Values.backend.postgres.sslsecret.sslcertSubPath }}
-            - mountPath: /postgres-client.key
+            - mountPath: /client.key
               name: {{ .Values.backend.postgres.sslsecret.name }}
               subPath: {{ .Values.backend.postgres.sslsecret.sslkeySubPath }}
-            {{- end }}
             {{- end }}
       {{- end }}
       containers:
@@ -161,13 +164,13 @@ spec:
               value: {{ .Values.backend.postgres.sslmode }}
             {{- if .Values.backend.postgres.sslsecret.sslrootcertSubPath }}
             - name: BINDPLANE_POSTGRES_SSL_ROOT_CERT
-              value: /postgres-ca.crt
+              value: /postgres-tls/ca.crt
             {{- end }}
             {{- if .Values.backend.postgres.sslsecret.sslcertSubPath }}
             - name: BINDPLANE_POSTGRES_SSL_CERT
-              value: /postgres-client.crt
+              value: /postgres-tls/client.crt
             - name: BINDPLANE_POSTGRES_SSL_KEY
-              value: /postgres-client.key
+              value: /postgres-tls/client.key
             {{- end }}
             - name: BINDPLANE_POSTGRES_MAX_CONNECTIONS
               value: "{{ .Values.backend.postgres.maxConnections }}"
@@ -444,19 +447,8 @@ spec:
             {{- end }}
             {{- end }}
             {{- if .Values.backend.postgres.sslsecret.name }}
-            {{- if .Values.backend.postgres.sslsecret.sslrootcertSubPath }}
-            - mountPath: /postgres-ca.crt
-              name: {{ .Values.backend.postgres.sslsecret.name }}
-              subPath: {{ .Values.backend.postgres.sslsecret.sslrootcertSubPath }}
-            {{- end }}
-            {{- if .Values.backend.postgres.sslsecret.sslcertSubPath }}
-            - mountPath: /postgres-client.crt
-              name: {{ .Values.backend.postgres.sslsecret.name }}
-              subPath: {{ .Values.backend.postgres.sslsecret.sslcertSubPath }}
-            - mountPath: /postgres-client.key
-              name: {{ .Values.backend.postgres.sslsecret.name }}
-              subPath: {{ .Values.backend.postgres.sslsecret.sslkeySubPath }}
-            {{- end }}
+            - mountPath: /postgres-tls
+              name: postgres-tls-dir
             {{- end }}
             {{- if len .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
@@ -506,10 +498,15 @@ spec:
         {{- end }}
         {{- end }}
         {{- if .Values.backend.postgres.sslsecret.name }}
+        - name: postgres-tls-dir
+          emptyDir: {}
         - name: {{ .Values.backend.postgres.sslsecret.name }}
           secret:
             defaultMode: 0400
             secretName: {{ .Values.backend.postgres.sslsecret.name }}
+        - name: postgres-tls-init
+          configMap:
+            name: postgres-tls-init
         {{- end }}
         {{- if len .Values.extraVolumes }}
         {{- toYaml .Values.extraVolumes | nindent 8 }}

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -49,6 +49,33 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.backend.postgres.sslsecret.name }}
+      initContainers:
+        - name: postgres-tls
+          image: busybox
+          command:
+          - sh
+          - -c
+          - /bin/chmod 0400 /postgres-ca.crt /postgres-client.crt /postgres-client.key || true
+          volumeMounts:
+            {{- if .Values.backend.postgres.sslsecret.name }}
+            - mountPath: /postgres-tls
+              name: postgres-tls-dir
+            {{- if .Values.backend.postgres.sslsecret.sslrootcertSubPath }}
+            - mountPath: /postgres-ca.crt
+              name: {{ .Values.backend.postgres.sslsecret.name }}
+              subPath: {{ .Values.backend.postgres.sslsecret.sslrootcertSubPath }}
+            {{- end }}
+            {{- if .Values.backend.postgres.sslsecret.sslcertSubPath }}
+            - mountPath: /postgres-client.crt
+              name: {{ .Values.backend.postgres.sslsecret.name }}
+              subPath: {{ .Values.backend.postgres.sslsecret.sslcertSubPath }}
+            - mountPath: /postgres-client.key
+              name: {{ .Values.backend.postgres.sslsecret.name }}
+              subPath: {{ .Values.backend.postgres.sslsecret.sslkeySubPath }}
+            {{- end }}
+            {{- end }}
+      {{- end }}
       containers:
         - name: server
           image: {{ include "bindplane.image" . }}:{{ include "bindplane.tag" . }}

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -1,3 +1,17 @@
+{{- if .Values.backend.postgres.sslsecret.name }}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: postgres-tls-init
+data:
+  init.sh: |
+    #!/bin/sh
+    set -e
+    cp /ca.crt /client.crt /client.key /postgres-tls
+    chmod 0400 /postgres-tls/*
+    chown -R 65534:65534 /postgres-tls
+{{ end }}
+---
 apiVersion: apps/v1
 kind: {{ include "bindplane.deployment_type" . }}
 metadata:
@@ -56,24 +70,25 @@ spec:
           command:
           - sh
           - -c
-          - /bin/chmod 0400 /postgres-ca.crt /postgres-client.crt /postgres-client.key || true
+          - /bin/sh /init.sh
           volumeMounts:
-            {{- if .Values.backend.postgres.sslsecret.name }}
+            - name: postgres-tls-init
+              mountPath: /init.sh
+              subPath: init.sh
             - mountPath: /postgres-tls
               name: postgres-tls-dir
             {{- if .Values.backend.postgres.sslsecret.sslrootcertSubPath }}
-            - mountPath: /postgres-ca.crt
+            - mountPath: /ca.crt
               name: {{ .Values.backend.postgres.sslsecret.name }}
               subPath: {{ .Values.backend.postgres.sslsecret.sslrootcertSubPath }}
             {{- end }}
             {{- if .Values.backend.postgres.sslsecret.sslcertSubPath }}
-            - mountPath: /postgres-client.crt
+            - mountPath: /client.crt
               name: {{ .Values.backend.postgres.sslsecret.name }}
               subPath: {{ .Values.backend.postgres.sslsecret.sslcertSubPath }}
-            - mountPath: /postgres-client.key
+            - mountPath: /client.key
               name: {{ .Values.backend.postgres.sslsecret.name }}
               subPath: {{ .Values.backend.postgres.sslsecret.sslkeySubPath }}
-            {{- end }}
             {{- end }}
       {{- end }}
       containers:
@@ -178,13 +193,13 @@ spec:
               value: {{ .Values.backend.postgres.sslmode }}
             {{- if .Values.backend.postgres.sslsecret.sslrootcertSubPath }}
             - name: BINDPLANE_POSTGRES_SSL_ROOT_CERT
-              value: /postgres-ca.crt
+              value: /postgres-tls/ca.crt
             {{- end }}
             {{- if .Values.backend.postgres.sslsecret.sslcertSubPath }}
             - name: BINDPLANE_POSTGRES_SSL_CERT
-              value: /postgres-client.crt
+              value: /postgres-tls/client.crt
             - name: BINDPLANE_POSTGRES_SSL_KEY
-              value: /postgres-client.key
+              value: /postgres-tls/client.key
             {{- end }}
             - name: BINDPLANE_POSTGRES_MAX_CONNECTIONS
               value: "{{ .Values.backend.postgres.maxConnections }}"
@@ -463,19 +478,8 @@ spec:
             {{- end }}
             {{- end }}
             {{- if .Values.backend.postgres.sslsecret.name }}
-            {{- if .Values.backend.postgres.sslsecret.sslrootcertSubPath }}
-            - mountPath: /postgres-ca.crt
-              name: {{ .Values.backend.postgres.sslsecret.name }}
-              subPath: {{ .Values.backend.postgres.sslsecret.sslrootcertSubPath }}
-            {{- end }}
-            {{- if .Values.backend.postgres.sslsecret.sslcertSubPath }}
-            - mountPath: /postgres-client.crt
-              name: {{ .Values.backend.postgres.sslsecret.name }}
-              subPath: {{ .Values.backend.postgres.sslsecret.sslcertSubPath }}
-            - mountPath: /postgres-client.key
-              name: {{ .Values.backend.postgres.sslsecret.name }}
-              subPath: {{ .Values.backend.postgres.sslsecret.sslkeySubPath }}
-            {{- end }}
+            - mountPath: /postgres-tls
+              name: postgres-tls-dir
             {{- end }}
             {{- if len .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
@@ -549,10 +553,15 @@ spec:
         {{- end }}
         {{- end }}
         {{- if .Values.backend.postgres.sslsecret.name }}
+        - name: postgres-tls-dir
+          emptyDir: {}
         - name: {{ .Values.backend.postgres.sslsecret.name }}
           secret:
             defaultMode: 0400
             secretName: {{ .Values.backend.postgres.sslsecret.name }}
+        - name: postgres-tls-init
+          configMap:
+            name: postgres-tls-init
         {{- end }}
         {{- if len .Values.extraVolumes }}
         {{- toYaml .Values.extraVolumes | nindent 8 }}

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -1,16 +1,3 @@
-{{- if .Values.backend.postgres.sslsecret.name }}
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: postgres-tls-init
-data:
-  init.sh: |
-    #!/bin/sh
-    set -e
-    cp /ca.crt /client.crt /client.key /postgres-tls
-    chmod 0400 /postgres-tls/*
-    chown -R 65534:65534 /postgres-tls
-{{ end }}
 ---
 apiVersion: apps/v1
 kind: {{ include "bindplane.deployment_type" . }}

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -149,6 +149,16 @@ spec:
               value: {{ .Values.backend.postgres.database }}
             - name: BINDPLANE_POSTGRES_SSL_MODE
               value: {{ .Values.backend.postgres.sslmode }}
+            {{- if .Values.backend.postgres.sslsecret.sslrootcertSubPath }}
+            - name: BINDPLANE_POSTGRES_SSL_ROOT_CERT
+              value: /postgres-ca.crt
+            {{- end }}
+            {{- if .Values.backend.postgres.sslsecret.sslcertSubPath }}
+            - name: BINDPLANE_POSTGRES_SSL_CERT
+              value: /postgres-client.crt
+            - name: BINDPLANE_POSTGRES_SSL_KEY
+              value: /postgres-client.key
+            {{- end }}
             - name: BINDPLANE_POSTGRES_MAX_CONNECTIONS
               value: "{{ .Values.backend.postgres.maxConnections }}"
             {{- else }}
@@ -425,6 +435,21 @@ spec:
               subPath: {{ .Values.prometheus.tls.secret.keySubPath }}
             {{- end }}
             {{- end }}
+            {{- if .Values.backend.postgres.sslsecret.name }}
+            {{- if .Values.backend.postgres.sslsecret.sslrootcertSubPath }}
+            - mountPath: /postgres-ca.crt
+              name: {{ .Values.backend.postgres.sslsecret.name }}
+              subPath: {{ .Values.backend.postgres.sslsecret.sslrootcertSubPath }}
+            {{- end }}
+            {{- if .Values.backend.postgres.sslsecret.sslcertSubPath }}
+            - mountPath: /postgres-client.crt
+              name: {{ .Values.backend.postgres.sslsecret.name }}
+              subPath: {{ .Values.backend.postgres.sslsecret.sslcertSubPath }}
+            - mountPath: /postgres-client.key
+              name: {{ .Values.backend.postgres.sslsecret.name }}
+              subPath: {{ .Values.backend.postgres.sslsecret.sslkeySubPath }}
+            {{- end }}
+            {{- end }}
             {{- if len .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
@@ -495,6 +520,12 @@ spec:
             defaultMode: 0400
             secretName: {{ .Values.prometheus.tls.secret.name }}
         {{- end }}
+        {{- end }}
+        {{- if .Values.backend.postgres.sslsecret.name }}
+        - name: {{ .Values.backend.postgres.sslsecret.name }}
+          secret:
+            defaultMode: 0400
+            secretName: {{ .Values.backend.postgres.sslsecret.name }}
         {{- end }}
         {{- if len .Values.extraVolumes }}
         {{- toYaml .Values.extraVolumes | nindent 8 }}

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apps/v1
 kind: {{ include "bindplane.deployment_type" . }}
 metadata:

--- a/charts/bindplane/templates/configmap.yaml
+++ b/charts/bindplane/templates/configmap.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.backend.postgres.sslsecret.name }}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: postgres-tls-init
+data:
+  init.sh: |
+    #!/bin/sh
+    cp /ca.crt /client.crt /client.key /postgres-tls
+    chmod 0400 /postgres-tls/*
+    chown -R 65534:65534 /postgres-tls
+{{ end }}

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -18,8 +18,20 @@ backend:
     port: 5432
     # -- Database to use.
     database: ""
-    # -- SSL mode to use when connecting to Postgres over TLS. See the [postgres ssl documentation](https://jdbc.postgresql.org/documentation/ssl/) for valid options.
+    # -- SSL mode to use when connecting to Postgres over TLS. Supported options include "disable", "require", "verify-ca", "verify-full". See the [postgres ssl documentation](https://jdbc.postgresql.org/documentation/ssl/) for more information.
     sslmode: "disable"
+    sslsecret:
+      # -- Name of the secret that contains the Postgres TLS certificate(s). When SSL mode is set to
+      # `verify-ca` or `verify-full`, this secret will be used to mount certificates into the BindPlane
+      # container.
+      name: ""
+      # -- Path to the CA certificate used to verify the Postgres server's certificate.
+      sslrootcertSubPath: ""
+      # -- Path to the client certificate used to authenticate with the Postgres server, when mutual TLS is required.
+      sslcertSubPath: ""
+      # -- Path to the client private key used to authenticate with the Postgres server, when mutual TLS is required.
+      # Required when `sslcertSubPath` is set.
+      sslkeySubPath: ""
     # -- Username to use when connecting to Postgres.
     username: ""
     # -- Password for the username used to connect to Postgres.

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -23,7 +23,7 @@ backend:
     sslsecret:
       # -- Name of the secret that contains the Postgres TLS certificate(s). When SSL mode is set to
       # `verify-ca` or `verify-full`, this secret will be used to mount certificates into the BindPlane
-      # container.
+      # container. Requires BindPlane v1.56.0 or newer.
       name: ""
       # -- Path to the CA certificate used to verify the Postgres server's certificate.
       sslrootcertSubPath: ""

--- a/test/cases/postgres/values.yaml
+++ b/test/cases/postgres/values.yaml
@@ -1,0 +1,40 @@
+# Required options
+config:
+  username: bpuser
+  password: bppass
+  sessions_secret: 4484766F-5016-4077-B8E0-0DE1D637854B
+  licenseUseSecret: true
+
+backend:
+  type: postgres
+  postgres:
+    host: postgres.postgres.svc.cluster.local
+    database: bindplane
+    username: postgres
+    password: password
+    maxConnections: 12
+    sslmode: verify-ca
+    sslsecret:
+      name: postgres-tls
+      sslrootcertSubPath: ca.crt
+      sslcertSubPath: tls.crt
+      sslkeySubPath: tls.key
+
+replicas: 2
+
+resources:
+  requests:
+    memory: 100Mi
+    cpu: 100m
+  limits:
+    memory: 100Mi
+    cpu: 100m
+
+jobs:
+  resources:
+    requests:
+      memory: 100Mi
+      cpu: 100m
+    limits:
+      memory: 100Mi
+      cpu: 100m

--- a/test/cases/postgres/values.yaml
+++ b/test/cases/postgres/values.yaml
@@ -17,8 +17,8 @@ backend:
     sslsecret:
       name: postgres-tls
       sslrootcertSubPath: ca.crt
-      sslcertSubPath: tls.crt
-      sslkeySubPath: tls.key
+      sslcertSubPath: client.crt
+      sslkeySubPath: client.key
 
 replicas: 2
 

--- a/test/helper/postgres/postgres.yaml
+++ b/test/helper/postgres/postgres.yaml
@@ -3,6 +3,19 @@ apiVersion: v1
 metadata:
   name: postgres
 ---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: postgres-tls-init
+  namespace: postgres
+data:
+  init.sh: |
+    #!/bin/sh
+    set -e
+    cp /ca.crt /server.crt /server.key /postgres-tls
+    chmod 0400 /postgres-tls/*
+    chown -R 1001:1001 /postgres-tls
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -29,8 +42,29 @@ spec:
           volumeMounts:
           - name: database
             mountPath: /data
+        - name: postgres-tls
+          image: busybox
+          command:
+          - sh
+          - -c
+          - /bin/sh /init.sh
+          volumeMounts:
+          - name: postgres-tls-init
+            mountPath: /init.sh
+            subPath: init.sh
+          - name: postgres-tls-dir
+            mountPath: /postgres-tls
+          - name: postgres-tls
+            mountPath: /ca.crt
+            subPath: ca.crt
+          - name: postgres-tls
+            mountPath: /server.crt
+            subPath: server.crt
+          - name: postgres-tls
+            mountPath: /server.key
+            subPath: server.key
       containers:
-        - image: postgres:14.7-alpine3.17
+        - image: bitnami/postgresql:14
           name: postgres
           ports:
             - containerPort: 5432
@@ -42,19 +76,35 @@ spec:
             limits:
               memory: 100Mi
           env:
-            - name: POSTGRES_PASSWORD
+            - name: POSTGRESQL_PASSWORD
               value: password
-            - name: PGDATA
-              value: /data/postgresql
+            - name: POSTGRESQL_ENABLE_TLS
+              value: "yes"
+            - name: POSTGRESQL_TLS_CERT_FILE
+              value: /postgres-tls/server.crt
+            - name: POSTGRESQL_TLS_KEY_FILE
+              value: /postgres-tls/server.key
+            - name: POSTGRESQL_TLS_CA_FILE
+              value: /postgres-tls/ca.crt
           volumeMounts:
-            - mountPath: /data
+            - mountPath: /bitnami/postgresql
               name: database
+            - mountPath: /postgres-tls
+              name: postgres-tls-dir
           livenessProbe:
             tcpSocket:
               port: 5432
       volumes:
         - name: database
           emptyDir: {}
+        - name:  postgres-tls
+          secret:
+            secretName:  postgres-tls
+        - name: postgres-tls-dir
+          emptyDir: {}
+        - name: postgres-tls-init
+          configMap:
+            name: postgres-tls-init
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

This PR requires BindPlane v1.56.0, which will release May 8th.

- Updated the test script ldap.sh to handle ldap and postgres certificates, for creating certs in CI
- Added or updated the following `backend.postgres` options
  - sslmode
  - sslsecret
    - name: Name of the secret containing the optional certificates
    - sslcertSubPath: Name of the key in the secret containing the client certificate
    - sslkeySubPath: Name of the key in the secret containing the client private key
    - sslrootcertsubPath: Name of the key in the secret containing the certificate authority used to verify the server certificates authenticity

Added an `initContainer` to `bindplane` and `bindplane-jobs` deployments. This container is used to configure certificate permissions. The postgres client will refuse to start if the certificates are world readable. By default, files mounted from a secret will be world readable. To get around this, the init container will copy the files to an emptyDir volume and set their permissions. The environment variables that point to the TLS certificates will use the copy in the emptyDir volume.

Updated the `bindplane` and `bindplane-jobs` deployments with the following
- Environment variables
  - BINDPLANE_POSTGRES_SSL_ROOT_CERT
  - BINDPLANE_POSTGRES_SSL_CERT
  - BINDPLANE_POSTGRES_SSL_KEY
- volume and volume mounts
  - emptyDir containing the certificates with appropriate file permissions

## Testing

I have a CloudSQL instance that requires mTLS. With the certs downloaded (I can share these). Latency is pretty bad, but it does work when using minikube locally.

```bash
minikube start
minikube addons enable ingress 
kubectl apply -f test/helper/pubsub/pubsub.yaml 
```

I created the bindplane and postgres secret with:

```bash
kubectl create secret generic bindplane \
  --from-literal=license=$BINDPLANE_LICENSE

kubectl create secret generic postgres-tls \
  --from-file server-ca.pem \
  --from-file client-cert.pem \
  --from-file client-key.pem
```

My values file looks like this:

```yaml
config:
  username: bpuser
  password: bppass
  sessions_secret: 4484766F-5016-4077-B8E0-0DE1D637854B
  licenseUseSecret: true 

eventbus:
  type: 'pubsub'
  pubsub:
    projectid: 'my-project'
    topic: 'bindplane'
    insecure: true
    endpoint: "pubsub-emulator.pubsub.svc.cluster.local:8681"

backend:
  type: postgres
  postgres:
    host: redacted
    database: bindplane
    username: redacted
    password: redacted
    maxConnections: 12
    sslmode: verify-ca
    sslsecret:
      name: postgres-tls
      sslrootcertSubPath: server-ca.pem
      sslcertSubPath: client-cert.pem
      sslkeySubPath: client-key.pem

replicas: 2

resources:
  requests:
    memory: 100Mi
    cpu: 100m
  limits:
    memory: 100Mi
    cpu: 100m

jobs:
  resources:
    requests:
      memory: 100Mi
      cpu: 100m
    limits:
      memory: 100Mi
      cpu: 100m

ingress:
  enable: true
  host: bindplane.local
  class: nginx
```

```bash
helm install --values ./values.yaml  bindplane charts/bindplane
```

The pods should spin up without issue, connecting to pubsub emulator (in cluster) and cloudsql.

On macOS, run `minikube tunnel` and navigate to http://bindplane.local (make sure you have an /etc/hosts entry for this hostname, pointing to `127.0.0.1`).

You should be able to create and delete configs, integrating that access to Postgres is working correctly.

If you turn SSL off with `backend.postgres.sslmode: disable` and redeploy, the new pod will fail to startup (old pod stays in place).

```bash
helm upgrade \
  --install bindplane \
  charts/bindplane \
  --values values.yaml
```

The new pod will log the following:
```
{"level":"info","timestamp":"2024-05-13T15:15:29.240Z","message":"Using postgres store"}
{"level":"error","timestamp":"2024-05-13T15:15:29.375Z","message":"failed to build server during server startup","error":"failed to load store: build store: failed to init Postgres storage: pq: pg_hba.conf rejects connection for host \"redacted\", user \"redacted\", database \"postgres\", no encryption"}
Error: failed to load store: build store: failed to init Postgres storage: pq: pg_hba.conf rejects connection for host "redacted", user "redacted", database "postgres", no encryption
```

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
