### PR TITLE
chore: Use tagged release for transform agent

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an observability pipeline.
 type: application
 # The chart's version
-version: 1.10.3
+version: 1.10.4
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.56.0

--- a/charts/bindplane/templates/_helpers.tpl
+++ b/charts/bindplane/templates/_helpers.tpl
@@ -49,7 +49,7 @@ The Transform Agent image to use
 The Transform Agent image tag to use
 */}}
 {{- define "bindplane.transform_agent_tag" -}}
-{{- printf "%s" (default (printf "latest") .Values.transform_agent.tag) }}
+{{- printf "%s" (default (printf "%s-bindplane" .Chart.AppVersion) .Values.transform_agent.tag) }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

This will fix an issue where the user could be operating with an older version of the transform agent. Each time the chart is updated, the matching transform agent will be configured.

Requires BindPlane v1.56.0 or newer. Will mention this in the release notes.

## Testing

```bash
$ helm template charts/bindplane | grep image | grep -v Pull                     
   
          image: ghcr.io/observiq/bindplane-transform-agent:1.56.0-bindplane
          image: ghcr.io/observiq/bindplane-ee:1.56.0
          image: ghcr.io/observiq/bindplane-prometheus:1.56.0
```

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
