### PR TITLE
feat(postgres): Support credential secret

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an observability pipeline.
 type: application
 # The chart's version
-version: 1.12.0
+version: 1.13.0
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.63.1

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -42,6 +42,9 @@ BindPlane OP is an observability pipeline.
 | autoscaling.targetMemoryUtilizationPercentage | int | `60` | Autoscaling target Memory usage percentage. |
 | backend.bbolt.storageClass | string | `""` | The Kubernetes storage class to use for the volumeClaimTemplate. If unset, the volume claim will use the cluster's default storage class. |
 | backend.bbolt.volumeSize | string | `"10Gi"` | Persistent volume size. |
+| backend.postgres.credentialSecret.name | string | `""` | Kubernetes secret name that contains the Postgres username and password. |
+| backend.postgres.credentialSecret.passwordKey | string | `""` | The secret's subPath which contains the password. |
+| backend.postgres.credentialSecret.usernameKey | string | `""` | The secret's subPath which contains the username. |
 | backend.postgres.database | string | `""` | Database to use. |
 | backend.postgres.host | string | `"localhost"` | Hostname or IP address of the Postgres server. |
 | backend.postgres.maxConnections | int | `100` | Max number of connections to use when communicating with Postgres. |

--- a/charts/bindplane/templates/bindplane-jobs.yaml
+++ b/charts/bindplane/templates/bindplane-jobs.yaml
@@ -167,9 +167,25 @@ spec:
             - name: BINDPLANE_POSTGRES_PORT
               value: "{{ .Values.backend.postgres.port }}"
             - name: BINDPLANE_POSTGRES_USERNAME
+              {{- if .Values.backend.postgres.credentialSecret.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.backend.postgres.credentialSecret.name }}
+                  key: {{ .Values.backend.postgres.credentialSecret.usernameKey }}
+                  optional: false
+              {{- else }}
               value: {{ .Values.backend.postgres.username }}
+              {{- end }}
             - name: BINDPLANE_POSTGRES_PASSWORD
+              {{- if .Values.backend.postgres.credentialSecret.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.backend.postgres.credentialSecret.name }}
+                  key: {{ .Values.backend.postgres.credentialSecret.passwordKey }}
+                  optional: false
+              {{- else }}
               value: {{ .Values.backend.postgres.password }}
+              {{- end }}
             - name: BINDPLANE_POSTGRES_DATABASE
               value: {{ .Values.backend.postgres.database }}
             - name: BINDPLANE_POSTGRES_SSL_MODE

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -182,9 +182,25 @@ spec:
             - name: BINDPLANE_POSTGRES_PORT
               value: "{{ .Values.backend.postgres.port }}"
             - name: BINDPLANE_POSTGRES_USERNAME
+              {{- if .Values.backend.postgres.credentialSecret.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.backend.postgres.credentialSecret.name }}
+                  key: {{ .Values.backend.postgres.credentialSecret.usernameKey }}
+                  optional: false
+              {{- else }}
               value: {{ .Values.backend.postgres.username }}
+              {{- end }}
             - name: BINDPLANE_POSTGRES_PASSWORD
+              {{- if .Values.backend.postgres.credentialSecret.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.backend.postgres.credentialSecret.name }}
+                  key: {{ .Values.backend.postgres.credentialSecret.passwordKey }}
+                  optional: false
+              {{- else }}
               value: {{ .Values.backend.postgres.password }}
+              {{- end }}
             - name: BINDPLANE_POSTGRES_DATABASE
               value: {{ .Values.backend.postgres.database }}
             - name: BINDPLANE_POSTGRES_SSL_MODE

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -40,9 +40,9 @@ backend:
       # -- Kubernetes secret name that contains the Postgres username and password.
       name: ""
       # -- The secret's subPath which contains the username.
-      usernamePath: ""
+      usernameKey: ""
       # -- The secret's subPath which contains the password.
-      passwordPath: ""
+      passwordKey: ""
     # -- Max number of connections to use when communicating with Postgres.
     maxConnections: 100
 

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -36,6 +36,13 @@ backend:
     username: ""
     # -- Password for the username used to connect to Postgres.
     password: ""
+    credentialSecret:
+      # -- Kubernetes secret name that contains the Postgres username and password.
+      name: ""
+      # -- The secret's subPath which contains the username.
+      usernamePath: ""
+      # -- The secret's subPath which contains the password.
+      passwordPath: ""
     # -- Max number of connections to use when communicating with Postgres.
     maxConnections: 100
 

--- a/test/cases/postgres/values.yaml
+++ b/test/cases/postgres/values.yaml
@@ -10,8 +10,10 @@ backend:
   postgres:
     host: postgres.postgres.svc.cluster.local
     database: bindplane
-    username: postgres
-    password: password
+    credentialSecret:
+      name: postgres-credentials
+      usernameKey: username
+      passwordKey: password
     maxConnections: 12
     sslmode: verify-ca
     sslsecret:

--- a/test/helper/postgres/postgres.tls.yaml
+++ b/test/helper/postgres/postgres.tls.yaml
@@ -123,3 +123,12 @@ spec:
     app: postgres
   sessionAffinity: None
   type: ClusterIP
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-credentials
+type: Opaque
+data:
+  username: cG9zdGdyZXM=
+  password: cGFzc3dvcmQ=

--- a/test/helper/postgres/postgres.yaml
+++ b/test/helper/postgres/postgres.yaml
@@ -71,3 +71,12 @@ spec:
     app: postgres
   sessionAffinity: None
   type: ClusterIP
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-credentials
+type: Opaque
+data:
+  username: cG9zdGdyZXM=
+  password: cGFzc3dvcmQ=


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

## Testing

Setup minikube. Make sure you have a license in your environment at `$BINDPLANE_LICENSE`

```bash
minikube start --nodes 1 --cpus 4 --memory 12g 

kubectl create secret generic bindplane \
  --from-literal=license=$BINDPLANE_LICENSE

minikube addons enable metrics-server
minikube addons enable ingress
```

Deploy Postgres. This will also deploy a secret to the `default` namespace, which will be used to test this PR.

```bash
kubectl apply -f test/helper/postgres/postgres.yaml 
```
```
$ kubectl get secret  postgres-credentials -o yaml
apiVersion: v1
data:
  password: cGFzc3dvcmQ=
  username: cG9zdGdyZXM=
```

Create a `values.yaml` with the following contents:

```yaml
config:
  username: bpuser
  password: bppass
  sessions_secret: 4484766F-5016-4077-B8E0-0DE1D637854B
  licenseUseSecret: true

backend:
  type: postgres
  postgres:
    host: postgres.postgres.svc.cluster.local
    database: bindplane
    credentialSecret:
      name: postgres-credentials
      usernameKey: username
      passwordKey: password
    maxConnections: 12
    sslmode: disable

replicas: 1

resources:
  requests:
    memory: 100Mi
    cpu: 100m
  limits:
    memory: 100Mi
    cpu: 100m

jobs:
  resources:
    requests:
      memory: 100Mi
      cpu: 100m
    limits:
      memory: 100Mi
      cpu: 100m
```

Deploy

```bash
helm template charts/bindplane/ --values values.yaml | kubectl apply -f -
```

The pods will come up without error. It is okay if the main bindplane pod restarted once or twice. It will restart until the `jobs` pod has come up.

If BindPlane starts without error, Postgres is working. You can check the UI if you want.

```bash
kubectl port-forward deploy/release-name-bindplane 3011:3001
```

Navigate to port 3011 http://localhost:3011/



## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
