### PR TITLE
fix(istio): Rename nats client port to tcp to resolve istio protocol detection issue

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,3 +11,4 @@ In order for changes to be captured in changelog correctly please add one of the
 - [ ] Tests for the changes have been added (for bug fixes / features)
 - [ ] Docs have been added / updated (for bug fixes / features)
 - [ ] CI passes
+- [ ] Changes to ports, services, or other networking have been tested with **istio**

--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an observability pipeline.
 type: application
 # The chart's version
-version: 1.13.0
+version: 1.13.1
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.63.1

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 1.12.0](https://img.shields.io/badge/Version-1.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.63.1](https://img.shields.io/badge/AppVersion-1.63.1-informational?style=flat-square)
+![Version: 1.13.1](https://img.shields.io/badge/Version-1.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.63.1](https://img.shields.io/badge/AppVersion-1.63.1-informational?style=flat-square)
 
 BindPlane OP is an observability pipeline.
 

--- a/charts/bindplane/templates/bindplane-jobs.yaml
+++ b/charts/bindplane/templates/bindplane-jobs.yaml
@@ -280,7 +280,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: BINDPLANE_NATS_CLIENT_ENDPOINT
-              value: nats://{{ include "bindplane.fullname" . }}-nats-client-headless.{{ .Release.Namespace }}.svc.cluster.local:4222
+              value: nats://{{ include "bindplane.fullname" . }}-nats-headless.{{ .Release.Namespace }}.svc.cluster.local:4222
             - name: BINDPLANE_NATS_CLIENT_SUBJECT
               value: bindplane-event-bus
             {{- end }}

--- a/charts/bindplane/templates/bindplane-nats.yaml
+++ b/charts/bindplane/templates/bindplane-nats.yaml
@@ -48,7 +48,7 @@ spec:
             - containerPort: 3001
               name: http            
             - containerPort: 4222
-              name: nats-client
+              name: tcp
             - containerPort: 6222
               name: nats-cluster
             - containerPort: 8222

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -295,7 +295,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: BINDPLANE_NATS_CLIENT_ENDPOINT
-              value: nats://{{ include "bindplane.fullname" . }}-nats-client-headless.{{ .Release.Namespace }}.svc.cluster.local:4222
+              value: nats://{{ include "bindplane.fullname" . }}-nats-headless.{{ .Release.Namespace }}.svc.cluster.local:4222
             - name: BINDPLANE_NATS_CLIENT_SUBJECT
               value: bindplane-event-bus
             {{- end }}

--- a/charts/bindplane/templates/service.yaml
+++ b/charts/bindplane/templates/service.yaml
@@ -61,7 +61,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "bindplane.fullname" . }}-nats-client-headless
+  name: {{ include "bindplane.fullname" . }}-nats-headless
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- if .Values.service.annotations }}
@@ -77,8 +77,8 @@ spec:
   ports:
     - port: 4222
       protocol: TCP
-      targetPort: nats-client
-      name: nats-client
+      targetPort: tcp
+      name: tcp
   selector:
     app.kubernetes.io/name: {{ include "bindplane.name" . }}
     app.kubernetes.io/stack: bindplane


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Removes the word "client" from port 4222, to prevent istio from auto detecting the wrong protocol.

See
- https://github.com/istio/istio/issues/28623
- https://github.com/AgathEmmanuel/RentIt/commit/47902f9d951c0c8055e0fdbade971957fca9f003

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
