### PR TITLE
chore(deprecate): Kafka event bus

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an observability pipeline.
 type: application
 # The chart's version
-version: 1.13.5
+version: 1.13.6
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.67.0

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -79,22 +79,6 @@ BindPlane OP is an observability pipeline.
 | dev.prometheus.image.tag | string | `"v2.47.2"` |  |
 | email.sendgrid.token | string | `""` | The sendgrid API token to use when authenticating to Sendgrid. |
 | email.type | string | `""` | The optional email backend type to use. Valid options include `sendgrid`. Requires an auth type other than `system`. |
-| eventbus.kafka.auth.plain.password | string | `""` | Password to use for plain authentication. |
-| eventbus.kafka.auth.plain.username | string | `""` | Username to use for plain authentication. |
-| eventbus.kafka.auth.sasl.mechanism | string | `""` | Mechanism for SASL authentication. One of plain|scramSHA256|scramSHA512. |
-| eventbus.kafka.auth.sasl.password | string | `""` | Password to use for SASL authentication. |
-| eventbus.kafka.auth.sasl.username | string | `""` | Username to use for SASL authentication. |
-| eventbus.kafka.auth.sasl.version | string | `""` | Version of SASL authentication to use. One of 0|1". |
-| eventbus.kafka.auth.type | string | `""` | How to authenticate to Kafka. One of: none|plainText|sasl. |
-| eventbus.kafka.brokers | string | `""` | Comma separated list of brokers to use, in the form of `host:port`. |
-| eventbus.kafka.protocolVersion | string | `""` | Protocol version of the Kafka brokers in 'MAJOR.MINOR.PATCH' format |
-| eventbus.kafka.tls.enable | bool | `false` | Whether or not to use TLS when connecting to Kafka. |
-| eventbus.kafka.tls.insecure | bool | `false` | Whether or not to skip verification of the Kafka broker certificate(s). |
-| eventbus.kafka.tls.secret.caSubPath | string | `""` | The secret's subPath which contains the certificate authority. |
-| eventbus.kafka.tls.secret.crtSubPath | string | `""` | The secret's subPath which contains the certificate for mutual TLS. |
-| eventbus.kafka.tls.secret.keySubPath | string | `""` | The secret's subPath which contains the private key for mutual TLS. |
-| eventbus.kafka.tls.secret.name | string | `nil` | Kubernetes TLS secret name. |
-| eventbus.kafka.topic | string | `""` | Topic to use. |
 | eventbus.pubsub.credentials.secret | string | `""` | Optional Kubernetes secret which contains Google Cloud JSON service account credentials. Not required when running within Google Cloud with the Pub/Sub scope enabled. |
 | eventbus.pubsub.credentials.subPath | string | `""` | Sub path for the secret which contains the Google Cloud credential JSON |
 | eventbus.pubsub.endpoint | string | `""` | For testing against an emulator only. |

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -125,7 +125,7 @@ prometheus:
 
 
 eventbus:
-  # The eventbus type to use when BindPlane is deployed with multiple pods (Deployment). Available options include `pubsub`, `kafka`, `nats`. By default, this option is not required as BindPlane OP operates as a StatefulSet with one pod.
+  # The eventbus type to use when BindPlane is deployed with multiple pods (Deployment). Available options include `pubsub`, or `nats`. By default, this option is not required as BindPlane OP operates as a StatefulSet with one pod.
   type: ""
 
   pubsub:
@@ -151,44 +151,30 @@ eventbus:
     # -- For testing against an emulator only.
     insecure: false
 
-  kafka:
-    # -- Comma separated list of brokers to use, in the form of `host:port`.
-    brokers: ""
-    # -- Protocol version of the Kafka brokers in 'MAJOR.MINOR.PATCH' format
-    protocolVersion: ""
-    # -- Topic to use.
-    topic: ""
-    auth:
-      # -- How to authenticate to Kafka. One of: none|plainText|sasl.
-      type: ""
-      plain:
-        # -- Username to use for plain authentication.
-        username: ""
-        # -- Password to use for plain authentication.
-        password: ""
-      sasl:
-        # -- Username to use for SASL authentication.
-        username: ""
-        # -- Password to use for SASL authentication.
-        password: ""
-        # -- Mechanism for SASL authentication. One of plain|scramSHA256|scramSHA512.
-        mechanism: ""
-        # -- Version of SASL authentication to use. One of 0|1".
-        version: ""
-    tls:
-      # -- Whether or not to use TLS when connecting to Kafka.
-      enable: false
-      # -- Whether or not to skip verification of the Kafka broker certificate(s).
-      insecure: false
-      secret:
-        # -- Kubernetes TLS secret name.
-        name:
-        # -- The secret's subPath which contains the certificate authority.
-        caSubPath: ""
-        # -- The secret's subPath which contains the certificate for mutual TLS.
-        crtSubPath: ""
-        # -- The secret's subPath which contains the private key for mutual TLS.
-        keySubPath: ""
+  # Kafka is deprecated and will be removed in a future release, please use NATS instead.
+  # https://observiq.com/docs/advanced-setup/kubernetes-installation/server/components/eventbus
+  # kafka:
+  #   brokers: ""
+  #   protocolVersion: ""
+  #   topic: ""
+  #   auth:
+  #     type: ""
+  #     plain:
+  #       username: ""
+  #       password: ""
+  #     sasl:
+  #       username: ""
+  #       password: ""
+  #       mechanism: ""
+  #       version: ""
+  #   tls:
+  #     enable: false
+  #     insecure: false
+  #     secret:
+  #       name:
+  #       caSubPath: ""
+  #       crtSubPath: ""
+  #       keySubPath: ""
 
 auth:
   # Supported options:


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Kafka Event Bus has been deprecate in favor of [NATS](https://observiq.com/docs/advanced-setup/kubernetes-installation/server/components/eventbus) . NATS is embedded within BindPlane does not require third party infrastructure, and is 100% managed by the Helm chart.

Enabling NATS is as simple as this:

```yaml
# values file
eventbus:
  type: nats
```

The chart will continue to function with Kafka, however, bug fixes and feature requests will result in urging the user to use NATS.

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
- [ ] Changes to ports, services, or other networking have been tested with **istio**
