### PR TITLE
feat: Support configuring affinity rules

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an observability pipeline.
 type: application
 # The chart's version
-version: 1.14.1
+version: 1.15.0
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.70.0

--- a/charts/bindplane/templates/bindplane-jobs.yaml
+++ b/charts/bindplane/templates/bindplane-jobs.yaml
@@ -38,6 +38,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.affinity.jobs }}
+      affinity:
+      {{- toYaml .Values.affinity.jobs | nindent 8 }}
+      {{- end }}
       {{- if .Values.backend.postgres.sslsecret.name }}
       initContainers:
         - name: postgres-tls

--- a/charts/bindplane/templates/bindplane-nats.yaml
+++ b/charts/bindplane/templates/bindplane-nats.yaml
@@ -40,6 +40,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.affinity.nats }}
+      affinity:
+      {{- toYaml .Values.affinity.nats | nindent 8 }}
+      {{- end }}
       containers:
         - name: server
           image: {{ include "bindplane.image" . }}:{{ include "bindplane.tag" . }}

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -40,6 +40,10 @@ spec:
         {{- toYaml .Values.extraPodLabels | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.affinity.bindplane }}
+      affinity:
+      {{- toYaml .Values.affinity.bindplane | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "bindplane.fullname" . }}
       {{- with .Values.podSecurityContext }}
       securityContext:

--- a/charts/bindplane/templates/prometheus.yaml
+++ b/charts/bindplane/templates/prometheus.yaml
@@ -39,7 +39,7 @@ spec:
       {{- end }}
       {{- if .Values.affinity.prometheus }}
       affinity:
-      {{- .toYaml .Values.affinity.prometheus | nindent 8 }}
+      {{- toYaml .Values.affinity.prometheus | nindent 8 }}
       {{- end }}
       containers:
         - name: prometheus

--- a/charts/bindplane/templates/prometheus.yaml
+++ b/charts/bindplane/templates/prometheus.yaml
@@ -37,6 +37,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.affinity.prometheus }}
+      affinity:
+      {{- .toYaml .Values.affinity.prometheus | nindent 8 }}
+      {{- end }}
       containers:
         - name: prometheus
           image: {{ .Values.prometheus.image.name }}:{{ include "bindplane.tag" . }}

--- a/charts/bindplane/templates/transform-agent.yaml
+++ b/charts/bindplane/templates/transform-agent.yaml
@@ -25,9 +25,9 @@ spec:
         app.kubernetes.io/component: transform-agent
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-      {{- if .Values.affinity.transform-agent }}
+      {{- if .Values.affinity.transform_agent }}
       affinity:
-      {{- toYaml .Values.affinity.transform-agent | nindent 8 }}
+      {{- toYaml .Values.affinity.transform_agent | nindent 8 }}
       {{- end }}
       serviceAccountName: default
       {{- with .Values.podSecurityContext }}

--- a/charts/bindplane/templates/transform-agent.yaml
+++ b/charts/bindplane/templates/transform-agent.yaml
@@ -25,6 +25,10 @@ spec:
         app.kubernetes.io/component: transform-agent
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      {{- if .Values.affinity.transform-agent }}
+      affinity:
+      {{- toYaml .Values.affinity.transform-agent | nindent 8 }}
+      {{- end }}
       serviceAccountName: default
       {{- with .Values.podSecurityContext }}
       securityContext:

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -429,7 +429,7 @@ affinity:
   prometheus: {}
   # -- This is for configuring spec.template.spec.affinity on the BindPlane transform agent pod.
   # The transform agent pod is a single pod deployment.
-  transform-agent: {}
+  transform_agent: {}
 
 autoscaling:
   # -- Whether or not autoscaling should be enabled. Requires an eventbus to be configured.

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -427,6 +427,9 @@ affinity:
   # -- This is for configuring spec.template.spec.affinity on the BindPlane Prometheus pod.
   # The Prometheus pod is a single pod deployment.
   prometheus: {}
+  # -- This is for configuring spec.template.spec.affinity on the BindPlane transform agent pod.
+  # The transform agent pod is a single pod deployment.
+  transform-agent: {}
 
 autoscaling:
   # -- Whether or not autoscaling should be enabled. Requires an eventbus to be configured.

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -414,6 +414,20 @@ trace:
 # -- Number of replicas to use for the BindPlane server. Should not be set if `autoscaling.enable` is set to `true`. 0 means this option will not be set.
 replicas: 0
 
+# -- Configure the affinity for BindPlane, BindPlane NATS, BindPlane Jobs, and BindPlane Prometheus pods.
+affinity:
+  # -- This is for configuring spec.template.spec.affinity on the BindPlane deployment pods.
+  bindplane: {}
+  # -- This is for configuring spec.template.spec.affinity on the BindPlane NATS statefulset
+  # pods, if NATS is enabled.
+  nats: {}
+  # -- This is for configuring spec.template.spec.affinity on the BindPlane Jobs pod.
+  # The jobs pod is a single pod deployment.
+  jobs: {}
+  # -- This is for configuring spec.template.spec.affinity on the BindPlane Prometheus pod.
+  # The Prometheus pod is a single pod deployment.
+  prometheus: {}
+
 autoscaling:
   # -- Whether or not autoscaling should be enabled. Requires an eventbus to be configured.
   enable: false

--- a/test/cases/all/values.yaml
+++ b/test/cases/all/values.yaml
@@ -62,3 +62,60 @@ trace:
 replicas: 3
 autoscaling:
   enable: false
+
+affinity:
+  bindplane:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            topologyKey: failure-domain.beta.kubernetes.io/zone
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                    - server
+  nats:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            topologyKey: failure-domain.beta.kubernetes.io/zone
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                    - nats
+  jobs:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+            - key: topology.kubernetes.io/zone
+              operator: In
+              values:
+                - us-central1-b
+  prometheus:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+            - key: topology.kubernetes.io/zone
+              operator: In
+              values:
+                - us-central1-f
+
+  transform-agent:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            topologyKey: failure-domain.beta.kubernetes.io/zone
+            labelSelector:
+              matchExpressions:
+                - key: topology.kubernetes.io/zone
+                  operator: In
+                  values:
+                    - us-central1-a


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

This PR updates the helm chart to support configuring affinity for Bindplane, NATS, Prometheus, and the Jobs pod(s).

A section to configure the affinity for each resource has been added to the `values.yaml` file and the templates have been updated accordingly.

This was tested manually using the following configuration when deploying the helm chart:
```yaml
config:
  sessions_secret: 4484766F-5016-4077-B8E0-0DE1D637854B
  licenseUseSecret: true
  username: admin
  password: admin

backend:
  type: postgres
  postgres:
    host: postgres.postgres.svc.cluster.local
    database: bindplane
    username: postgres
    password: password
    maxConnections: 20

eventbus:
  type: nats

replicas: 5

resources:
  requests:
    memory: 100Mi
    cpu: 100m
  limits:
    memory: 100Mi

nats:
  resources:
    requests:
      memory: 100Mi
      cpu: 100m
    limits:
      memory: 100Mi

affinity:
  bindplane:
    podAntiAffinity:
      preferredDuringSchedulingIgnoredDuringExecution:
        - weight: 100
          podAffinityTerm:
            topologyKey: failure-domain.beta.kubernetes.io/zone
            labelSelector:
              matchExpressions:
                - key: app.kubernetes.io/component
                  operator: In
                  values:
                    - server
  nats:
    podAntiAffinity:
      preferredDuringSchedulingIgnoredDuringExecution:
        - weight: 100
          podAffinityTerm:
            topologyKey: failure-domain.beta.kubernetes.io/zone
            labelSelector:
              matchExpressions:
                - key: app.kubernetes.io/component
                  operator: In
                  values:
                    - nats
  jobs:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
          - matchExpressions:
            - key: topology.kubernetes.io/zone
              operator: In
              values:
                - us-central1-b
  prometheus:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
          - matchExpressions:
            - key: topology.kubernetes.io/zone
              operator: In
              values:
                - us-central1-f
```

The GKE cluster deployed did not have any nodes in `us-central1-f`, therefore, the affinity rule set for the prometheus deployment did not allow the pod to be scheduled. The other affinity rule allowed scheduling  for the jobs pod because nodes in that region/zone were available. Bindplane/NATS pods deployed successfully, as well. 

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
- [ ] Changes to ports, services, or other networking have been tested with **istio**
