### PR TITLE
feat: add `topologySpreadConstraints` configuration option for deployments

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an observability pipeline.
 type: application
 # The chart's version
-version: 1.15.1
+version: 1.16.0
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.72.0

--- a/charts/bindplane/templates/bindplane-jobs.yaml
+++ b/charts/bindplane/templates/bindplane-jobs.yaml
@@ -42,6 +42,10 @@ spec:
       affinity:
       {{- toYaml .Values.affinity.jobs | nindent 8 }}
       {{- end }}
+      {{- if .Values.topologySpreadConstraints.jobs }}
+      topologySpreadConstraints:
+      {{- toYaml .Values.topologySpreadConstraints.jobs | nindent 8 }}
+      {{- end }}
       {{- if .Values.backend.postgres.sslsecret.name }}
       initContainers:
         - name: postgres-tls

--- a/charts/bindplane/templates/bindplane-nats.yaml
+++ b/charts/bindplane/templates/bindplane-nats.yaml
@@ -44,6 +44,10 @@ spec:
       affinity:
       {{- toYaml .Values.affinity.nats | nindent 8 }}
       {{- end }}
+      {{- if .Values.topologySpreadConstraints.nats }}
+      topologySpreadConstraints:
+      {{- toYaml .Values.topologySpreadConstraints.nats | nindent 8 }}
+      {{- end }}
       containers:
         - name: server
           image: {{ include "bindplane.image" . }}:{{ include "bindplane.tag" . }}

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -44,6 +44,10 @@ spec:
       affinity:
       {{- toYaml .Values.affinity.bindplane | nindent 8 }}
       {{- end }}
+      {{- if .Values.topologySpreadConstraints.bindplane }}
+      topologySpreadConstraints:
+      {{- toYaml .Values.topologySpreadConstraints.bindplane | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "bindplane.fullname" . }}
       {{- with .Values.podSecurityContext }}
       securityContext:

--- a/charts/bindplane/templates/prometheus.yaml
+++ b/charts/bindplane/templates/prometheus.yaml
@@ -41,6 +41,10 @@ spec:
       affinity:
       {{- toYaml .Values.affinity.prometheus | nindent 8 }}
       {{- end }}
+      {{- if .Values.topologySpreadConstraints.prometheus }}
+      topologySpreadConstraints:
+      {{- toYaml .Values.topologySpreadConstraints.prometheus | nindent 8 }}
+      {{- end }}
       containers:
         - name: prometheus
           image: {{ .Values.prometheus.image.name }}:{{ include "bindplane.tag" . }}

--- a/charts/bindplane/templates/transform-agent.yaml
+++ b/charts/bindplane/templates/transform-agent.yaml
@@ -29,6 +29,10 @@ spec:
       affinity:
       {{- toYaml .Values.affinity.transform_agent | nindent 8 }}
       {{- end }}
+      {{- if .Values.topologySpreadConstraints.transform_agent }}
+      topologySpreadConstraints:
+      {{- toYaml .Values.topologySpreadConstraints.transform_agent | nindent 8 }}
+      {{- end }}
       serviceAccountName: default
       {{- with .Values.podSecurityContext }}
       securityContext:

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -431,6 +431,22 @@ affinity:
   # The transform agent pod is a single pod deployment.
   transform_agent: {}
 
+topologySpreadConstraints:
+  # -- spec.template.spec.topologySpreadConstraints on the BindPlane deployment pods.
+  bindplane: {}
+  # -- This is for configuring spec.template.spec.topologySpreadConstraints on the BindPlane NATS statefulset
+  # pods, if NATS is enabled.
+  nats: {}
+  # -- This is for configuring spec.template.spec.topologySpreadConstraints on the BindPlane Jobs pod.
+  # The jobs pod is a single pod deployment.
+  jobs: {}
+  # -- This is for configuring spec.template.spec.topologySpreadConstraints on the BindPlane Prometheus pod.
+  # The Prometheus pod is a single pod deployment.
+  prometheus: {}
+  # -- This is for configuring spec.template.spec.topologySpreadConstraints on the BindPlane transform agent pod.
+  # The transform agent pod is a single pod deployment.
+  transform_agent: {}
+
 autoscaling:
   # -- Whether or not autoscaling should be enabled. Requires an eventbus to be configured.
   enable: false

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -433,19 +433,19 @@ affinity:
 
 topologySpreadConstraints:
   # -- spec.template.spec.topologySpreadConstraints on the BindPlane deployment pods.
-  bindplane: {}
+  bindplane: []
   # -- This is for configuring spec.template.spec.topologySpreadConstraints on the BindPlane NATS statefulset
   # pods, if NATS is enabled.
-  nats: {}
+  nats: []
   # -- This is for configuring spec.template.spec.topologySpreadConstraints on the BindPlane Jobs pod.
   # The jobs pod is a single pod deployment.
-  jobs: {}
+  jobs: []
   # -- This is for configuring spec.template.spec.topologySpreadConstraints on the BindPlane Prometheus pod.
   # The Prometheus pod is a single pod deployment.
-  prometheus: {}
+  prometheus: []
   # -- This is for configuring spec.template.spec.topologySpreadConstraints on the BindPlane transform agent pod.
   # The transform agent pod is a single pod deployment.
-  transform_agent: {}
+  transform_agent: []
 
 autoscaling:
   # -- Whether or not autoscaling should be enabled. Requires an eventbus to be configured.

--- a/test/cases/all/values.yaml
+++ b/test/cases/all/values.yaml
@@ -119,3 +119,44 @@ affinity:
                   operator: In
                   values:
                     - us-central1-a
+
+topologySpreadConstraints:
+  bindplane:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: server
+
+  nats:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: nats
+
+  jobs:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: jobs
+
+  prometheus:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: prometheus
+
+  transform_agent:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: transform_agent

--- a/test/cases/all/values.yaml
+++ b/test/cases/all/values.yaml
@@ -159,4 +159,4 @@ topologySpreadConstraints:
       whenUnsatisfiable: DoNotSchedule
       labelSelector:
         matchLabels:
-          app.kubernetes.io/component: transform_agent
+          app.kubernetes.io/component: transform-agent


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

This PR adds a `topologySpreadConstraints` configuration option to the `values.yaml` for the following deployments/resource:
- bindplane
- bindplane-nats
- bindplane-jobs
- prometheus
- transform_agent

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
- [ ] Changes to ports, services, or other networking have been tested with **istio**
