### PR TITLE
feat: Node selector

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an observability pipeline.
 type: application
 # The chart's version
-version: 1.16.0
+version: 1.17.0
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.72.0

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -116,6 +116,12 @@ BindPlane OP is an observability pipeline.
 | nats.resources.limits.memory | string | `"1000Mi"` | Memory limit for the NATs server pods, when event bus type is `nats`. |
 | nats.resources.requests.cpu | string | `"1000m"` | CPU request for the NATs server pods, when event bus type is `nats`. |
 | nats.resources.requests.memory | string | `"1000Mi"` | Memory request for the NATs server pods, when event bus type is `nats`. |
+| nodeSelector | object | `{"bindplane":{},"jobs":{},"nats":{},"prometheus":{},"transform_agent":{}}` | Configure the nodeSelector for BindPlane, BindPlane NATS, BindPlane Jobs, and BindPlane Prometheus pods. |
+| nodeSelector.bindplane | object | `{}` | This is for configuring spec.template.spec.nodeSelector on the BindPlane deployment pods when using the bbolt backend. |
+| nodeSelector.jobs | object | `{}` | This is for configuring spec.template.spec.nodeSelector on the BindPlane Jobs pod. The jobs pod is a single pod deployment. |
+| nodeSelector.nats | object | `{}` | This is for configuring spec.template.spec.nodeSelector on the BindPlane NATS statefulset pods, if NATS is enabled. |
+| nodeSelector.prometheus | object | `{}` | This is for configuring spec.template.spec.nodeSelector on the BindPlane Prometheus pod. The Prometheus pod is a single pod deployment. |
+| nodeSelector.transform_agent | object | `{}` | This is for configuring spec.template.spec.nodeSelector on the BindPlane transform agent pod. The transform agent pod is a single pod deployment. |
 | podSecurityContext | object | `{"fsGroup":65534}` | The Pod spec's securityContext: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod. |
 | prometheus.auth.password | string | `""` | Prometheus basic authentication password. |
 | prometheus.auth.type | string | `"none"` | Prometheus authentication. Supported options include `none` and `basic`. |

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 1.16.0](https://img.shields.io/badge/Version-1.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.72.0](https://img.shields.io/badge/AppVersion-1.72.0-informational?style=flat-square)
+![Version: 1.17.0](https://img.shields.io/badge/Version-1.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.72.0](https://img.shields.io/badge/AppVersion-1.72.0-informational?style=flat-square)
 
 BindPlane OP is an observability pipeline.
 

--- a/charts/bindplane/templates/bindplane-jobs.yaml
+++ b/charts/bindplane/templates/bindplane-jobs.yaml
@@ -39,6 +39,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.affinity.jobs }}
+      {{- if .Values.nodeSelector.jobs }}
+      nodeSelector:
+      {{- toYaml .Values.nodeSelector.jobs | nindent 8 }}
+      {{- end }}
       affinity:
       {{- toYaml .Values.affinity.jobs | nindent 8 }}
       {{- end }}

--- a/charts/bindplane/templates/bindplane-nats.yaml
+++ b/charts/bindplane/templates/bindplane-nats.yaml
@@ -40,6 +40,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.nodeSelector.nats }}
+      nodeSelector:
+      {{- toYaml .Values.nodeSelector.nats | nindent 8 }}
+      {{- end }}
       {{- if .Values.affinity.nats }}
       affinity:
       {{- toYaml .Values.affinity.nats | nindent 8 }}

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -40,6 +40,10 @@ spec:
         {{- toYaml .Values.extraPodLabels | nindent 8 }}
         {{- end }}
     spec:
+      {{- if and (eq .Values.backend.type "bbolt") (.Values.nodeSelector.bindplane) }}
+      nodeSelector:
+      {{- toYaml .Values.nodeSelector.bindplane | nindent 8 }}
+      {{- end }}
       {{- if .Values.affinity.bindplane }}
       affinity:
       {{- toYaml .Values.affinity.bindplane | nindent 8 }}

--- a/charts/bindplane/templates/prometheus.yaml
+++ b/charts/bindplane/templates/prometheus.yaml
@@ -37,6 +37,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.nodeSelector.prometheus }}
+      nodeSelector:
+      {{- toYaml .Values.nodeSelector.prometheus | nindent 8 }}
+      {{- end }}
       {{- if .Values.affinity.prometheus }}
       affinity:
       {{- toYaml .Values.affinity.prometheus | nindent 8 }}

--- a/charts/bindplane/templates/transform-agent.yaml
+++ b/charts/bindplane/templates/transform-agent.yaml
@@ -25,6 +25,10 @@ spec:
         app.kubernetes.io/component: transform-agent
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      {{- if .Values.nodeSelector.transform_agent }}
+      nodeSelector:
+      {{- toYaml .Values.nodeSelector.transform_agent | nindent 8 }}
+      {{- end }}
       {{- if .Values.affinity.transform_agent }}
       affinity:
       {{- toYaml .Values.affinity.transform_agent | nindent 8 }}

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -414,6 +414,23 @@ trace:
 # -- Number of replicas to use for the BindPlane server. Should not be set if `autoscaling.enable` is set to `true`. 0 means this option will not be set.
 replicas: 0
 
+# -- Configure the nodeSelector for BindPlane, BindPlane NATS, BindPlane Jobs, and BindPlane Prometheus pods.
+nodeSelector:
+  # -- This is for configuring spec.template.spec.nodeSelector on the BindPlane deployment pods when using the bbolt backend.
+  bindplane: {}
+  # -- This is for configuring spec.template.spec.nodeSelector on the BindPlane NATS statefulset
+  # pods, if NATS is enabled.
+  nats: {}
+  # -- This is for configuring spec.template.spec.nodeSelector on the BindPlane Jobs pod.
+  # The jobs pod is a single pod deployment.
+  jobs: {}
+  # -- This is for configuring spec.template.spec.nodeSelector on the BindPlane Prometheus pod.
+  # The Prometheus pod is a single pod deployment.
+  prometheus: {}
+  # -- This is for configuring spec.template.spec.nodeSelector on the BindPlane transform agent pod.
+  # The transform agent pod is a single pod deployment.
+  transform_agent: {}
+
 # -- Configure the affinity for BindPlane, BindPlane NATS, BindPlane Jobs, and BindPlane Prometheus pods.
 affinity:
   # -- This is for configuring spec.template.spec.affinity on the BindPlane deployment pods.

--- a/test/cases/all/values.yaml
+++ b/test/cases/all/values.yaml
@@ -160,3 +160,15 @@ topologySpreadConstraints:
       labelSelector:
         matchLabels:
           app.kubernetes.io/component: transform-agent
+
+nodeSelector:
+  bindplane:
+    kubernetes.io/hostname: minikube
+  nats:
+    kubernetes.io/hostname: minikube
+  jobs:
+    kubernetes.io/hostname: minikube
+  prometheus:
+    kubernetes.io/hostname: minikube
+  transform_agent:
+    kubernetes.io/hostname: minikube


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

This PR adds the ability to configure the `nodeSelector` for bindplane, nats, jobs, prometheus, and tranform_agent deployments.

Tested with the following configuration:
```yaml
config:
  sessions_secret: 4484766F-5016-4077-B8E0-0DE1D637854B
  licenseUseSecret: true
  username: admin
  password: admin

backend:
  type: bbolt

eventbus:
  type: nats

replicas: 5

resources:
  requests:
    memory: 100Mi
    cpu: 100m
  limits:
    memory: 100Mi

nats:
  resources:
    requests:
      memory: 100Mi
      cpu: 100m
    limits:
      memory: 100Mi

nodeSelector:
  bindplane:
    topology.kubernetes.io/zone: us-central1-b
  nats:
    topology.kubernetes.io/zone: us-central1-a
  jobs:
    topology.kubernetes.io/zone: us-central1-f
  prometheus:
    topology.kubernetes.io/zone: us-central1-f
  transform_agent:
    topology.kubernetes.io/zone: us-central1-a

```
Also tested when backend is postgres:
```yaml
backend:
  type: postgres
  postgres:
    host: postgres.postgres.svc.cluster.local
    database: bindplane
    username: postgres
    password: password
    maxConnections: 20
```

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
- [ ] Changes to ports, services, or other networking have been tested with **istio**
