### PR TITLE
feat: Support setting bindplane prometheus image tag

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an observability pipeline.
 type: application
 # The chart's version
-version: 1.17.2
+version: 1.17.3
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.73.0

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 1.17.2](https://img.shields.io/badge/Version-1.17.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.73.0](https://img.shields.io/badge/AppVersion-1.73.0-informational?style=flat-square)
+![Version: 1.17.3](https://img.shields.io/badge/Version-1.17.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.73.0](https://img.shields.io/badge/AppVersion-1.73.0-informational?style=flat-square)
 
 BindPlane OP is an observability pipeline.
 
@@ -126,6 +126,7 @@ BindPlane OP is an observability pipeline.
 | prometheus.extraPodLabels | object | `{}` | Optional arbitrary labels to add to the Prometheus pod. This option is only used when Prometheus is running as a StatefulSet managed by the chart (The default mode). |
 | prometheus.host | string | `""` | The Prometheus hostname or IP address used for querying and writing metrics. Defaults to the service name of the Prometheus StatefulSet deployed by this chart. |
 | prometheus.image.name | string | `"ghcr.io/observiq/bindplane-prometheus"` | Image name to be used. Defaults to `ghcr.io/observiq/bindplane-prometheus`. NOTE: The image tag is derived from the BindPlane server tag. |
+| prometheus.image.tag | string | `""` | Image tag to use. Defaults to the bindplane version defined in the Chart's release. This option should be used when a specific bindplane-prometheus image is required, or if using upstream Prometheus. |
 | prometheus.port | int | `9090` | The Prometheus TCP port used for querying and writing metrics. |
 | prometheus.queryPathPrefix | string | `""` | Optional Prometheus query path prefix. Useful when overriding the query endpoints when using systems such as Mimir. |
 | prometheus.remote | bool | `false` | When true, the chart will not deploy Prometheus. Instead, the user should provide a Prometheus instance to use. |

--- a/charts/bindplane/templates/_helpers.tpl
+++ b/charts/bindplane/templates/_helpers.tpl
@@ -32,10 +32,13 @@ The image to use
 {{- end -}}
 
 {{/*
-The image tag to use
+The image tags to use
 */}}
 {{- define "bindplane.tag" -}}
 {{- printf "%s" (default (printf "%s" .Chart.AppVersion) .Values.image.tag) }}
+{{- end -}}
+{{- define "prometheus.tag" -}}
+{{- printf "%s" (default (printf "%s" .Chart.AppVersion) .Values.prometheus.image.tag) }}
 {{- end -}}
 
 {{/*

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -567,7 +567,7 @@ spec:
         {{- if eq (include "bindplane.deployment_type" .) "StatefulSet" }}
         {{- if and (.Values.prometheus.enableSideCar) (eq .Values.prometheus.remote false)}}
         - name: prometheus
-          image: {{ .Values.prometheus.image.name }}:{{ include "bindplane.tag" . }}
+          image: {{ .Values.prometheus.image.name }}:{{ include "prometheus.tag" . }}
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true

--- a/charts/bindplane/templates/prometheus.yaml
+++ b/charts/bindplane/templates/prometheus.yaml
@@ -50,7 +50,7 @@ spec:
       {{- end }}
       containers:
         - name: prometheus
-          image: {{ .Values.prometheus.image.name }}:{{ include "bindplane.tag" . }}
+          image: {{ .Values.prometheus.image.name }}:{{ include "prometheus.tag" . }}
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -52,6 +52,8 @@ prometheus:
   image:
     # -- Image name to be used. Defaults to `ghcr.io/observiq/bindplane-prometheus`. NOTE: The image tag is derived from the BindPlane server tag.
     name: "ghcr.io/observiq/bindplane-prometheus"
+    # -- Image tag to use. Defaults to the bindplane version defined in the Chart's release. This option should be used when a specific bindplane-prometheus image is required, or if using upstream Prometheus.
+    tag: ""
   # -- When true, the chart will not deploy Prometheus. Instead, the user should provide a Prometheus instance to use.
   remote: false
   # -- When enabled, the Prometheus measurements backend will be deployed as a sidecar container. This option is only valid when BindPlane is running as a single node statefulset.


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Added a `prometheus.image.tag` option for overriding the default Prometheus image tag. The tag defaults to the BindPlane version.

Currently, the default image is `ghcr.io/observiq/bindplane-prometheus:1.73.0`. When I set `prometheus.image.tag: 1.70.0`, the chart correctly uses that image. Here is a diff of the YAML output from `helm template`:

```
<           image: ghcr.io/observiq/bindplane-prometheus:1.73.0
---
>           image: ghcr.io/observiq/bindplane-prometheus:1.70.0
```

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
- [ ] Changes to ports, services, or other networking have been tested with **istio**
