### PR TITLE
feat(prometheus): Switch to upstream prometheus as the default PRometheus image

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an observability pipeline.
 type: application
 # The chart's version
-version: 1.17.3
+version: 1.18.0
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.73.0

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 1.17.3](https://img.shields.io/badge/Version-1.17.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.73.0](https://img.shields.io/badge/AppVersion-1.73.0-informational?style=flat-square)
+![Version: 1.18.0](https://img.shields.io/badge/Version-1.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.73.0](https://img.shields.io/badge/AppVersion-1.73.0-informational?style=flat-square)
 
 BindPlane OP is an observability pipeline.
 
@@ -126,7 +126,7 @@ BindPlane OP is an observability pipeline.
 | prometheus.extraPodLabels | object | `{}` | Optional arbitrary labels to add to the Prometheus pod. This option is only used when Prometheus is running as a StatefulSet managed by the chart (The default mode). |
 | prometheus.host | string | `""` | The Prometheus hostname or IP address used for querying and writing metrics. Defaults to the service name of the Prometheus StatefulSet deployed by this chart. |
 | prometheus.image.name | string | `"ghcr.io/observiq/bindplane-prometheus"` | Image name to be used. Defaults to `ghcr.io/observiq/bindplane-prometheus`. NOTE: The image tag is derived from the BindPlane server tag. |
-| prometheus.image.tag | string | `""` | Image tag to use. Defaults to the bindplane version defined in the Chart's release. This option should be used when a specific bindplane-prometheus image is required, or if using upstream Prometheus. |
+| prometheus.image.tag | string | `"v2.54.1"` | Image tag to use. https://github.com/prometheus/prometheus/releases. |
 | prometheus.port | int | `9090` | The Prometheus TCP port used for querying and writing metrics. |
 | prometheus.queryPathPrefix | string | `""` | Optional Prometheus query path prefix. Useful when overriding the query endpoints when using systems such as Mimir. |
 | prometheus.remote | bool | `false` | When true, the chart will not deploy Prometheus. Instead, the user should provide a Prometheus instance to use. |

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -125,8 +125,8 @@ BindPlane OP is an observability pipeline.
 | prometheus.enableSideCar | bool | `false` | When enabled, the Prometheus measurements backend will be deployed as a sidecar container. This option is only valid when BindPlane is running as a single node statefulset. |
 | prometheus.extraPodLabels | object | `{}` | Optional arbitrary labels to add to the Prometheus pod. This option is only used when Prometheus is running as a StatefulSet managed by the chart (The default mode). |
 | prometheus.host | string | `""` | The Prometheus hostname or IP address used for querying and writing metrics. Defaults to the service name of the Prometheus StatefulSet deployed by this chart. |
-| prometheus.image.name | string | `"ghcr.io/observiq/bindplane-prometheus"` | Image name to be used. Defaults to `ghcr.io/observiq/bindplane-prometheus`. NOTE: The image tag is derived from the BindPlane server tag. |
-| prometheus.image.tag | string | `"v2.54.1"` | Image tag to use. https://github.com/prometheus/prometheus/releases. |
+| prometheus.image.name | string | `"prom/prometheus"` | Image name to be used. |
+| prometheus.image.tag | string | `"v2.54.1"` | Image tag to use. |
 | prometheus.port | int | `9090` | The Prometheus TCP port used for querying and writing metrics. |
 | prometheus.queryPathPrefix | string | `""` | Optional Prometheus query path prefix. Useful when overriding the query endpoints when using systems such as Mimir. |
 | prometheus.remote | bool | `false` | When true, the chart will not deploy Prometheus. Instead, the user should provide a Prometheus instance to use. |

--- a/charts/bindplane/templates/_helpers.tpl
+++ b/charts/bindplane/templates/_helpers.tpl
@@ -37,9 +37,6 @@ The image tags to use
 {{- define "bindplane.tag" -}}
 {{- printf "%s" (default (printf "%s" .Chart.AppVersion) .Values.image.tag) }}
 {{- end -}}
-{{- define "prometheus.tag" -}}
-{{- printf "%s" (default (printf "%s" .Chart.AppVersion) .Values.prometheus.image.tag) }}
-{{- end -}}
 
 {{/*
 The Transform Agent image to use

--- a/charts/bindplane/templates/prometheus.yaml
+++ b/charts/bindplane/templates/prometheus.yaml
@@ -1,5 +1,35 @@
 {{- if not .Values.prometheus.remote }}
 {{- if not .Values.prometheus.enableSideCar }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "bindplane.fullname" . }}-prometheus
+data:
+  prometheus.yml: |
+    scrape_configs: []
+    rule_files: [/etc/prometheus/rules.yml]
+  web.yml: |
+    # This file should be empty unless configured
+    # by the user. See the Prometheus auth and TLS
+    # docs here: https://prometheus.io/docs/prometheus/latest/configuration/https/
+  rules.yml: |
+    groups:
+    - name: configuration-rollups
+      interval: 1m
+      rules:
+      - record: bindplane_agent_measurements:rollup:rate:1m
+        expr: sum without (agent) (rate(bindplane_agent_measurements{}[1m9s999ms] offset 10s))
+    - name: 5m-configuration-rollups
+      interval: 5m
+      rules:
+      - record: bindplane_agent_measurements:rollup:rate:5m
+        expr: sum without (agent) (rate(bindplane_agent_measurements:1m{}[5m59s999ms] offset 10s))
+    - name: 1h-configuration-rollups
+      interval: 1h
+      rules:
+      - record: bindplane_agent_measurements:rollup:rate:1h
+        expr: sum without (agent) (rate(bindplane_agent_measurements:15m{}[1h14m59s999ms] offset 10s))
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -50,7 +80,17 @@ spec:
       {{- end }}
       containers:
         - name: prometheus
-          image: {{ .Values.prometheus.image.name }}:{{ include "prometheus.tag" . }}
+          image: prom/prometheus:v2.54.1
+          command:
+            - /bin/prometheus \
+            - --config.file "/etc/prometheus/prometheus.yml"
+            - --web.config.file "/etc/prometheus/web.yml"
+            - --storage.tsdb.retention.time "2d"
+            - --web.enable-remote-write-receiver
+            - --web.listen-address ":9090"
+            - --storage.tsdb.path "/prometheus"
+            - --web.console.templates "/etc/prometheus/consoles"
+            - --web.console.libraries "/etc/prometheus/console_libraries"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -70,6 +110,19 @@ spec:
           volumeMounts:
             - mountPath: /prometheus
               name: {{ include "bindplane.fullname" . }}-prometheus-data
+            - mountPath: /etc/prometheus/prometheus.yml
+              subPath: promethes.yml
+              name: config
+            - mountPath: /etc/prometheus/rules.yml
+              subPath: rules.yml
+              name: config
+            - mountPath: /etc/prometheus/web.yml
+              subPath: web.yml
+              name: config
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "bindplane.fullname" . }}-prometheus 
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: Retain
     whenScaled: Retain

--- a/charts/bindplane/templates/prometheus.yaml
+++ b/charts/bindplane/templates/prometheus.yaml
@@ -80,7 +80,7 @@ spec:
       {{- end }}
       containers:
         - name: prometheus
-          image: prom/prometheus:v2.54.1
+          image: {{ .Values.prometheus.image.name }}:{{ .Values.prometheus.image.tag }}
           command:
             - /bin/prometheus \
             - --config.file "/etc/prometheus/prometheus.yml"
@@ -122,7 +122,7 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: {{ include "bindplane.fullname" . }}-prometheus 
+            name: {{ include "bindplane.fullname" . }}-prometheus
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: Retain
     whenScaled: Retain

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -50,10 +50,10 @@ backend:
 # This is undocumented for now, as Prometheus support has not been released.
 prometheus:
   image:
-    # -- Image name to be used. Defaults to `ghcr.io/observiq/bindplane-prometheus`. NOTE: The image tag is derived from the BindPlane server tag.
-    name: "ghcr.io/observiq/bindplane-prometheus"
-    # -- Image tag to use. Defaults to the bindplane version defined in the Chart's release. This option should be used when a specific bindplane-prometheus image is required, or if using upstream Prometheus.
-    tag: ""
+    # -- Image name to be used.
+    name: "prom/prometheus"
+    # -- Image tag to use.
+    tag: "v2.54.1"
   # -- When true, the chart will not deploy Prometheus. Instead, the user should provide a Prometheus instance to use.
   remote: false
   # -- When enabled, the Prometheus measurements backend will be deployed as a sidecar container. This option is only valid when BindPlane is running as a single node statefulset.


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

The `bindplane-prometheus` image is useful because it bundles the required configuration and entrypoint with the upstream Prometheus binary. Unfortunately, some users have strict security requirements that require auditing of unapproved images, such as `ghcr.io/observiq/bindplane-prometheus`. This is a source of friction when `prom/prometheus` is already approved.

This PR removes `bindplane-prometheus` as the default and replaces it with `prom/prometheus`. This requires the following additional changes
- Addition of configmap for injecting the three configuration files via volume mounts
- Entrypoint command

This change will be transparent to the user. The latest and past few BindPlane releases used Prometheus v2.54.1, which is now the default `prometheus.image.tag` value. The configuration and entrypoint command remain unchanged.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
- [ ] Changes to ports, services, or other networking have been tested with **istio**
