### PR TITLE
feat(nats): Support configuring NATS to run as a Deployment

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an observability pipeline.
 type: application
 # The chart's version
-version: 1.18.0
+version: 1.19.0
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.73.0

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -108,6 +108,7 @@ BindPlane OP is an observability pipeline.
 | jobs.resources.requests.cpu | string | `"1000m"` | CPU request. |
 | jobs.resources.requests.memory | string | `"1000Mi"` | Memory request. |
 | multiAccount | bool | `false` | Whether or not to enable multi account (tenant). |
+| nats.deploymentType | string | `"StatefulSet"` | Deployment Type for NATs. Valid options include `StatefulSet` and `Deployment`, case sensitive. StatefulSet is recommended, and does not consume a volume mount. If your cluster is restricted to using Deployments, you can use that option instead. |
 | nats.resources | object | `{"limits":{"memory":"1000Mi"},"requests":{"cpu":"1000m","memory":"1000Mi"}}` | NATs server resources request block, when event bus type is `nats`. |
 | nats.resources.limits.memory | string | `"1000Mi"` | Memory limit for the NATs server pods, when event bus type is `nats`. |
 | nats.resources.requests.cpu | string | `"1000m"` | CPU request for the NATs server pods, when event bus type is `nats`. |

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 1.18.0](https://img.shields.io/badge/Version-1.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.73.0](https://img.shields.io/badge/AppVersion-1.73.0-informational?style=flat-square)
+![Version: 1.19.0](https://img.shields.io/badge/Version-1.19.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.73.0](https://img.shields.io/badge/AppVersion-1.73.0-informational?style=flat-square)
 
 BindPlane OP is an observability pipeline.
 

--- a/charts/bindplane/templates/bindplane-nats.yaml
+++ b/charts/bindplane/templates/bindplane-nats.yaml
@@ -1,6 +1,6 @@
 {{- if eq .Values.eventbus.type "nats" }}
 apiVersion: apps/v1
-kind: StatefulSet
+kind: {{ .Values.nats.deploymentType }}
 metadata:
   name: {{ include "bindplane.fullname" . }}-nats
   namespace: {{ .Release.Namespace }}
@@ -12,8 +12,10 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: 3
+  {{ if eq .Values.nats.deploymentType "StatefulSet" }}
   serviceName: {{ include "bindplane.fullname" . }}-nats-cluster-headless
   podManagementPolicy: Parallel
+  {{ end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "bindplane.name" . }}
@@ -166,7 +168,12 @@ spec:
             - name: BINDPLANE_NATS_SERVER_CLUSTER_PORT
               value: "6222"
             - name: BINDPLANE_NATS_SERVER_CLUSTER_ROUTES
+              {{ if eq .Values.nats.deploymentType "StatefulSet" }}
               value: nats://{{ include "bindplane.fullname" . }}-nats-0.{{ include "bindplane.fullname" . }}-nats-cluster-headless.{{ .Release.Namespace }}.svc.cluster.local:6222,nats://{{ include "bindplane.fullname" . }}-nats-1.{{ include "bindplane.fullname" . }}-nats-cluster-headless.{{ .Release.Namespace }}.svc.cluster.local:6222,nats://{{ include "bindplane.fullname" . }}-nats-2.{{ include "bindplane.fullname" . }}-nats-cluster-headless.{{ .Release.Namespace }}.svc.cluster.local:6222
+              {{ end }}
+              {{ if eq .Values.nats.deploymentType "Deployment" }}
+              value: nats://{{ include "bindplane.fullname" . }}-nats-cluster-headless.{{ .Release.Namespace }}.svc.cluster.local:6222
+              {{ end }}
             - name: BINDPLANE_NATS_CLIENT_NAME
               valueFrom:
                 fieldRef:

--- a/charts/bindplane/values.schema.json
+++ b/charts/bindplane/values.schema.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+      "nats": {
+        "type": "object",
+        "properties": {
+          "deploymentType": {
+            "type": "string",
+            "enum": ["StatefulSet", "Deployment"],
+            "description": "The type of NATS deployment, either StatefulSet or Deployment."
+          }
+        },
+        "required": ["deploymentType"],
+        "additionalProperties": true
+      }
+    }
+  }
+  

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -330,6 +330,10 @@ resources:
     # cpu: 1000m
 
 nats:
+  # -- Deployment Type for NATs. Valid options include `StatefulSet` and `Deployment`, case sensitive.
+  # StatefulSet is recommended, and does not consume a volume mount. If your cluster is restricted to
+  # using Deployments, you can use that option instead.
+  deploymentType: StatefulSet
   # -- NATs server resources request block, when event bus type is `nats`.
   resources:
     requests:


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

The current behavior is to deploy three NATS pods as a StatefulSet. This PR introduces the ability to deploy NATS as a deployment, defaulting to statefulset.

- When StatefulSet, set the following
  - serviceName
  - podManagementPolicy
- Set NATS routes based on deployment type
  - StatefulSet: Use all three pod FQDN
  - Deployment: Point to headless service

This change is motivated by some users being restricted to Deployments, they cannot use StatefulSets due to cluster restrictions in place by their organization.

## Testing

I tested by deploying to GKE + CloudSQL with the following config:

```yaml
config:
  username: redacted
  password: redacted
  sessions_secret: 4484766F-5016-4077-B8E0-0DE1D637854B
  server_url: redacted
  # The secret "bindplane" should exist and have the
  # key license with a license key as the value.
  # License is required in CI in order to use Postgres store.
  licenseUseSecret: true

ingress:
  enable: true
  host: redacted
  class: nginx

backend:
  type: postgres
  postgres:
    host: redacted
    database:  redacted
    username: redacted
    password: redacted
    maxConnections: 20
    
eventbus:
  type: nats

replicas: 5

resources:
  requests:
    memory: 250Mi
    cpu: 200m
  limits:
    memory: 250Mi

nats:
  # Optional, defaults to StatefulSet in charts/bindplane/values.yaml
  #deploymentType: StatefulSet
  resources:
    requests:
      memory: 200Mi
      cpu: 200m
    limits:
      memory: 200Mi
```

I started by deploying without setting `nats.deploymentType`. The result was NATS running the same way it always has, a StatefulSet.

I set `nats.deploymentType` to `Deployment` and performed an upgrade. Helm removed the StatefulSet and replaced it with a Deployment. I was able to perform rollouts to 200 agents during this upgrade.

Finally, I uninstalled the deployment and deployed from nothing using a Deployment. The new install deployed fine and was working right away, rollouts succeeding.

## Chart Upgrade Test

We need to be sure existing users can upgrade without issue. Using the same config as the previous section, I deployed the latest version of the chart.

```bash
helm upgrade \
  --install bindplane-ha \
  bindplane/bindplane \
  --values values.yaml
```

I verified functionality by performing a handful of rollouts.

I upgraded to this branch with:

```bash
helm upgrade \
  --install bindplane-ha \
  ./charts/bindplane \
  --values values.yaml
```

Because the values config did not change, this was a no-op.

I then set `nats.deploymentType: Deployment`, and re-tested. Everything is working as expected.

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
- [ ] Changes to ports, services, or other networking have been tested with **istio**
