### PR TITLE
feat: Support OTLP and Prometheus APM metrics

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an observability pipeline.
 type: application
 # The chart's version
-version: 1.19.2
+version: 1.20.0
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.74.2

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 1.19.2](https://img.shields.io/badge/Version-1.19.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.74.2](https://img.shields.io/badge/AppVersion-1.74.2-informational?style=flat-square)
+![Version: 1.20.0](https://img.shields.io/badge/Version-1.20.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.74.2](https://img.shields.io/badge/AppVersion-1.74.2-informational?style=flat-square)
 
 BindPlane OP is an observability pipeline.
 
@@ -107,6 +107,9 @@ BindPlane OP is an observability pipeline.
 | jobs.resources.limits.memory | string | `"1000Mi"` | Memory limit. |
 | jobs.resources.requests.cpu | string | `"1000m"` | CPU request. |
 | jobs.resources.requests.memory | string | `"1000Mi"` | Memory request. |
+| metrics.otlp.endpoint | string | `""` | Endpoint of the OTLP gRPC metrics receiver. Should be in the form of ip:port or host:port. |
+| metrics.otlp.insecure | bool | `false` | Set to `true` to disable TLS. Set to false if TLS is in use by the OTLP metrics receiver. |
+| metrics.type | string | `""` | Metrics type to use. Valid options include `otlp` and `prometheus`. When `otlp` is enabled, metrics are pushed to the configured OTel receiver. When `prometheus` is enabled, metrics are exposed in Prometheus format by BindPlane's HTTP server at `/metrics`. |
 | multiAccount | bool | `false` | Whether or not to enable multi account (tenant). |
 | nats.deploymentType | string | `"StatefulSet"` | Deployment Type for NATs. Valid options include `StatefulSet` and `Deployment`, case sensitive. StatefulSet is recommended, and does not consume a volume mount. If your cluster is restricted to using Deployments, you can use that option instead. |
 | nats.resources | object | `{"limits":{"memory":"1000Mi"},"requests":{"cpu":"1000m","memory":"1000Mi"}}` | NATs server resources request block, when event bus type is `nats`. |
@@ -157,7 +160,7 @@ BindPlane OP is an observability pipeline.
 | topologySpreadConstraints.nats | list | `[]` | This is for configuring spec.template.spec.topologySpreadConstraints on the BindPlane NATS statefulset pods, if NATS is enabled. |
 | topologySpreadConstraints.prometheus | list | `[]` | This is for configuring spec.template.spec.topologySpreadConstraints on the BindPlane Prometheus pod. The Prometheus pod is a single pod deployment. |
 | topologySpreadConstraints.transform_agent | list | `[]` | This is for configuring spec.template.spec.topologySpreadConstraints on the BindPlane transform agent pod. The transform agent pod is a single pod deployment. |
-| trace.otlp.endpoint | string | `""` | Endpoint of the OTLP trace receiver. Should be in the form of ip:port or host:port. |
+| trace.otlp.endpoint | string | `""` | Endpoint of the OTLP gRPC trace receiver. Should be in the form of ip:port or host:port. |
 | trace.otlp.insecure | bool | `false` | Set to `true` to disable TLS. Set to false if TLS is in use by the OTLP trace receiver. |
 | trace.otlp.samplingRate | string | `"1"` | Sampling rate between 0 and 1. 1 being 100% of traces are sent. |
 | trace.type | string | `""` | Trace type to use. Valid options include `otlp`. |

--- a/charts/bindplane/templates/bindplane-jobs.yaml
+++ b/charts/bindplane/templates/bindplane-jobs.yaml
@@ -20,6 +20,14 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        {{- if eq .Values.metrics.type "prometheus" }}
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "3001"
+        prometheus.io/scheme: http
+        prometheus.io/job-name: bindplane-op
+        {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "bindplane.name" . }}
         app.kubernetes.io/stack: bindplane
@@ -437,6 +445,20 @@ spec:
             - name: BINDPLANE_PROMETHEUS_TLS_KEY
               value: /prometheus-client.key
             {{- end }}
+            {{- end }}
+            {{- if eq .Values.metrics.type "prometheus" }}
+            - name: BINDPLANE_METRICS_TYPE
+              value: prometheus
+            - name: BINDPLANE_METRICS_PROMETHEUS_ENDPOINT
+              value: /metrics
+            {{- end }}
+            {{- if eq .Values.metrics.type "otlp" }}
+            - name: BINDPLANE_METRICS_TYPE
+              value: otlp
+            - name: BINDPLANE_METRICS_OTLP_ENDPOINT
+              value: {{ .Values.metrics.otlp.endpoint }}
+            - name: BINDPLANE_METRICS_OTLP_INSECURE
+              value: "{{ .Values.metrics.otlp.insecure }}"
             {{- end }}
             {{- if len .Values.extraEnv }}
             {{- toYaml .Values.extraEnv | nindent 12 }}

--- a/charts/bindplane/templates/bindplane-nats.yaml
+++ b/charts/bindplane/templates/bindplane-nats.yaml
@@ -24,6 +24,14 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        {{- if eq .Values.metrics.type "prometheus" }}
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "3001"
+        prometheus.io/scheme: http
+        prometheus.io/job-name: bindplane-op
+        {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "bindplane.name" . }}
         app.kubernetes.io/stack: bindplane
@@ -315,6 +323,20 @@ spec:
             - name: BINDPLANE_PROMETHEUS_TLS_KEY
               value: /prometheus-client.key
             {{- end }}
+            {{- end }}
+            {{- if eq .Values.metrics.type "prometheus" }}
+            - name: BINDPLANE_METRICS_TYPE
+              value: prometheus
+            - name: BINDPLANE_METRICS_PROMETHEUS_ENDPOINT
+              value: /metrics
+            {{- end }}
+            {{- if eq .Values.metrics.type "otlp" }}
+            - name: BINDPLANE_METRICS_TYPE
+              value: otlp
+            - name: BINDPLANE_METRICS_OTLP_ENDPOINT
+              value: {{ .Values.metrics.otlp.endpoint }}
+            - name: BINDPLANE_METRICS_OTLP_INSECURE
+              value: "{{ .Values.metrics.otlp.insecure }}"
             {{- end }}
             {{- if len .Values.extraEnv }}
             {{- toYaml .Values.extraEnv | nindent 12 }}

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -31,6 +31,14 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        {{- if eq .Values.metrics.type "prometheus" }}
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "3001"
+        prometheus.io/scheme: http
+        prometheus.io/job-name: bindplane-op
+        {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "bindplane.name" . }}
         app.kubernetes.io/stack: bindplane
@@ -468,6 +476,20 @@ spec:
             - name: BINDPLANE_PROMETHEUS_TLS_KEY
               value: /prometheus-client.key
             {{- end }}
+            {{- end }}
+            {{- if eq .Values.metrics.type "prometheus" }}
+            - name: BINDPLANE_METRICS_TYPE
+              value: prometheus
+            - name: BINDPLANE_METRICS_PROMETHEUS_ENDPOINT
+              value: /metrics
+            {{- end }}
+            {{- if eq .Values.metrics.type "otlp" }}
+            - name: BINDPLANE_METRICS_TYPE
+              value: otlp
+            - name: BINDPLANE_METRICS_OTLP_ENDPOINT
+              value: {{ .Values.metrics.otlp.endpoint }}
+            - name: BINDPLANE_METRICS_OTLP_INSECURE
+              value: "{{ .Values.metrics.otlp.insecure }}"
             {{- end }}
             {{- if len .Values.extraEnv }}
             {{- toYaml .Values.extraEnv | nindent 12 }}

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -410,12 +410,23 @@ trace:
   type: ""
 
   otlp:
-    # -- Endpoint of the OTLP trace receiver. Should be in the form of ip:port or host:port.
+    # -- Endpoint of the OTLP gRPC trace receiver. Should be in the form of ip:port or host:port.
     endpoint: ""
     # -- Set to `true` to disable TLS. Set to false if TLS is in use by the OTLP trace receiver.
     insecure: false
     # -- Sampling rate between 0 and 1. 1 being 100% of traces are sent.
     samplingRate: "1"
+
+metrics:
+  # -- Metrics type to use. Valid options include `otlp` and `prometheus`. When `otlp` is enabled, metrics
+  # are pushed to the configured OTel receiver. When `prometheus` is enabled, metrics are exposed in Prometheus
+  # format by BindPlane's HTTP server at `/metrics`.
+  type: ""
+  otlp:
+    # -- Endpoint of the OTLP gRPC metrics receiver. Should be in the form of ip:port or host:port.
+    endpoint: ""
+    # -- Set to `true` to disable TLS. Set to false if TLS is in use by the OTLP metrics receiver.
+    insecure: false
 
 # -- Number of replicas to use for the BindPlane server. Should not be set if `autoscaling.enable` is set to `true`. 0 means this option will not be set.
 replicas: 0

--- a/test/cases/nats/values.yaml
+++ b/test/cases/nats/values.yaml
@@ -50,3 +50,6 @@ nats:
       cpu: 100m
     limits:
       memory: 100Mi
+
+metrics:
+  type: prometheus


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Added a `metrics` config section, allowing users to enable OTLP or Prometheus metrics. The Prometheus metrics include the require annotations for being scraped by the [Kubernetes Prometheus Node](https://observiq.com/docs/resources/sources/kubernetes-prometheus-node) source.

When using the Prometheus metrics, users can configure the BindPlane node agent to autodetect and scrape the BindPlane pods for metrics.

When using OTLP, users can configure BindPlane to  push metrics to any OTLP receiver, such as the Node or Gateway agents.

## Testing

Deploy minikube

```bash
minikube start
minikube addons enable ingress 
kubectl apply -f test/helper/postgres/postgres.yaml 
```

Create a license secret from `$BINDPLANE_LICENSE`

```bash
kubectl create secret generic bindplane \
  --from-literal=license=$BINDPLANE_LICENSE
```

Create a `values.yaml` file in root of the helm repo.

```yaml
config:
  username: bpuser
  password: bppass
  sessions_secret: 4484766F-5016-4077-B8E0-0DE1D637854B
  server_url: http://bindplane.local:80
  licenseUseSecret: true

ingress:
  enable: true
  host: bindplane.local
  class: nginx

backend:
  type: postgres
  postgres:
    host: postgres.postgres.svc.cluster.local
    database: bindplane
    username: postgres
    password: password
    maxConnections: 20
    
eventbus:
  type: nats

replicas: 2

resources:
  requests:
    memory: 100Mi
    cpu: 100m
  limits:
    memory: 100Mi

nats:
  resources:
    requests:
      memory: 100Mi
      cpu: 100m
    limits:
      memory: 100Mi

metrics:
  #type: "prometheus"
  type: "otlp"
  otlp:
    endpoint: bindplane-node-agent.bindplane-agent.svc.cluster.local:4317
    insecure: true
```

Checkout this branch and deploy BindPlane

```bash
helm upgrade \
  --install bindplane-ha \
  ./charts/bindplane \
  --values values.yaml
```

Wait for the pods to come up:

```bash
kubectl get pod
```

Make sure you have the following `/etc/hosts` entry
```
127.0.0.1 bindplane.local
```

Run `minikube tunnel` in a new terminal, and then go to http://bindplane.local.

Sign in with `bpuser` / `bppass`.

1. Create a Kubernetes Node configuration
2. Attach OTLP source
3. Attach Prometheus source
4. Attach Dev Null destination
5. Add "Filter by Metric Name" processor to Prometheus, and include regex `bindplane_.*`
6. Install the Kubernetes Node agent by downloading the YAML and applying it to minikube
```bash
kubectl apply -f ~/Downloads/bindplane-agent.yaml
```

Once the agent is up, roll the config out and verify that OTLP metrics show up in Live Preview. You will need to wait up to 60 seconds.

![Screenshot from 2024-09-30 17-12-11](https://github.com/user-attachments/assets/fed9d405-f7e3-45a5-ab20-a0656c150eb4)

Edit `values.yaml` change `metrics.type: otlp` to `metrics.type: prometheus`. Re-deploy.

```bash
Checkout this branch and deploy BindPlane

```bash
helm upgrade \
  --install bindplane-ha \
  ./charts/bindplane \
  --values values.yaml
```

Once the pods are up, wait 60 seconds and check Prometheus live preview. You should be getting a handful of metrics. Notice that the metrics are prefixed with `bindplane_`, this is by design.

![Screenshot from 2024-09-30 17-15-09](https://github.com/user-attachments/assets/b95216f1-d208-4f88-be9c-45bf0dd19f9c)



## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
- [ ] Changes to ports, services, or other networking have been tested with **istio**
