### PR TITLE
fix: Do not deploy jobs pod when using local eventbus

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an observability pipeline.
 type: application
 # The chart's version
-version: 1.20.3
+version: 1.20.4
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.77.0

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 1.20.3](https://img.shields.io/badge/Version-1.20.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.77.0](https://img.shields.io/badge/AppVersion-1.77.0-informational?style=flat-square)
+![Version: 1.20.4](https://img.shields.io/badge/Version-1.20.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.77.0](https://img.shields.io/badge/AppVersion-1.77.0-informational?style=flat-square)
 
 BindPlane OP is an observability pipeline.
 

--- a/charts/bindplane/templates/bindplane-jobs.yaml
+++ b/charts/bindplane/templates/bindplane-jobs.yaml
@@ -1,4 +1,4 @@
-{{- if eq (include "bindplane.deployment_type" .) "Deployment" }}
+{{- if ne .Values.eventbus.type "" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -130,7 +130,7 @@ spec:
             - name: KUBERNETES_CONTAINER_NAME
               value: "server"
             - name: BINDPLANE_MODE
-              {{- if eq (include "bindplane.deployment_type" .) "StatefulSet" }}
+              {{- if eq .Values.eventbus.type "" }}
               value: all
               {{- else }}
               value: node

--- a/charts/bindplane/values.schema.json
+++ b/charts/bindplane/values.schema.json
@@ -1,19 +1,29 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "type": "object",
-    "properties": {
-      "nats": {
-        "type": "object",
-        "properties": {
-          "deploymentType": {
-            "type": "string",
-            "enum": ["StatefulSet", "Deployment"],
-            "description": "The type of NATS deployment, either StatefulSet or Deployment."
-          }
-        },
-        "required": ["deploymentType"],
-        "additionalProperties": true
-      }
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "nats": {
+      "type": "object",
+      "properties": {
+        "deploymentType": {
+          "type": "string",
+          "enum": ["StatefulSet", "Deployment"],
+          "description": "The type of NATS deployment, either StatefulSet or Deployment."
+        }
+      },
+      "required": ["deploymentType"],
+      "additionalProperties": true
+    },
+    "eventbus": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["", "nats", "pubsub", "kafka"],
+          "description": "The type of event bus used. Must be one of '', 'nats', 'pubsub', or 'kafka'."
+        }
+      },
+      "additionalProperties": true
     }
   }
-  
+}


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

When `eventbus.type: ""` (local), we should not deploy the jobs pod. We should also deploy the BindPlane pod with mode `all`.

It was assumed if "deployment type" was Deployment, that an event bus would be used for BindPlane HA. This is not the case. It is possible users would implement Postgres while sticking with local event bus (limited to one pod).

Deploying the jobs pod, and using mode "node" without an event bus will cause rollouts to fail.

## Testing

Create `values.yaml` with the following.

```yaml
config:
  username: bpuser
  password: bppass
  sessions_secret: 4484766F-5016-4077-B8E0-0DE1D637854B
  licenseUseSecret: true

backend:
  type: postgres
  postgres:
    host: postgres.postgres.svc.cluster.local
    database: bindplane
    username: postgres
    password: password
    maxConnections: 20

resources:
  requests:
    memory: 100Mi
    cpu: 100m
  limits:
    memory: 100Mi
```

Start minikube

```bash
minikube start
```

Deploy your license key

```bash
kubectl create secret generic bindplane \
  --from-literal=license=$BINDPLANE_LICENSE
```

Deploy Postgres

```bash
kubectl apply -f test/helper/postgres/postgres.yaml
```

Deploy the chart

```bash
helm upgrade \
  --install bindplane \
  ./charts/bindplane \
  --values values.yaml
```

You should see the following in the default namespace:

```
NAME                                            READY   STATUS    RESTARTS   AGE
bindplane-756cf87b5b-z6m9f                   1/1     Running   0          18m
bindplane-prometheus-0                       1/1     Running   0          32m
bindplane-transform-agent-5b87554f58-nlf2d   1/1     Running   0          32m
```

The `BINDPLANE_MODE` should be set to `all`.

```bash
kubectl get deploy bindplane -o json | \
  jq '.spec.template.spec.containers[0].env[] | select(.name=="BINDPLANE_MODE") | .value'
```

You can upgrade to a NATS environment if using an Enterprise license. Modify the values file.

```yaml
eventbus:
  type: nats
```

Redeploy:

```bash
helm upgrade \
  --install bindplane \
  ./charts/bindplane \
  --values values.yaml
```

This time, you should see the NATS pods, a jobs pod, and the deployment will have `mode: node`.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
- [ ] Changes to ports, services, or other networking have been tested with **istio**
