### PR TITLE
feat: Support pod terminationGracePeriodSeconds

### DIFF
--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -167,6 +167,12 @@ BindPlane OP is an observability pipeline.
 | resources.requests.cpu | string | `"1000m"` | CPU request. |
 | resources.requests.memory | string | `"1000Mi"` | Memory request. |
 | service.annotations | object | `{}` | Custom annotations which will be added to the service object. Useful for specifying things such as `cloud.google.com/backend-config`. |
+| terminationGracePeriodSeconds | object | `{"bindplane":60,"jobs":60,"nats":60,"prometheus":60,"transform_agent":60}` | Configure the terminationGracePeriodSeconds for BindPlane, BindPlane NATS, BindPlane Jobs, and BindPlane Prometheus pods. |
+| terminationGracePeriodSeconds.bindplane | int | `60` | This is for configuring spec.template.spec.terminationGracePeriodSeconds on the BindPlane deployment pods. |
+| terminationGracePeriodSeconds.jobs | int | `60` | This is for configuring spec.template.spec.terminationGracePeriodSeconds on the BindPlane Jobs pod. |
+| terminationGracePeriodSeconds.nats | int | `60` | This is for configuring spec.template.spec.terminationGracePeriodSeconds on the BindPlane NATS statefulset or deployment pods, if NATS is enabled. |
+| terminationGracePeriodSeconds.prometheus | int | `60` | This is for configuring spec.template.spec.terminationGracePeriodSeconds on the BindPlane Prometheus pod. |
+| terminationGracePeriodSeconds.transform_agent | int | `60` | This is for configuring spec.template.spec.terminationGracePeriodSeconds on the BindPlane transform agent pod. |
 | tolerations | object | `{}` | The Pod's tolerations |
 | topologySpreadConstraints.bindplane | list | `[]` | spec.template.spec.topologySpreadConstraints on the BindPlane deployment pods. |
 | topologySpreadConstraints.jobs | list | `[]` | This is for configuring spec.template.spec.topologySpreadConstraints on the BindPlane Jobs pod. |

--- a/charts/bindplane/templates/bindplane-jobs.yaml
+++ b/charts/bindplane/templates/bindplane-jobs.yaml
@@ -570,7 +570,7 @@ spec:
             preStop:
               exec:
                 command: ["sh", "-c", "sleep 5",]
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds.jobs }}
       volumes:
         {{- if eq .Values.eventbus.type "pubsub" }}
         {{- if .Values.eventbus.pubsub.credentials.secret }}

--- a/charts/bindplane/templates/bindplane-nats.yaml
+++ b/charts/bindplane/templates/bindplane-nats.yaml
@@ -433,7 +433,7 @@ spec:
             preStop:
               exec:
                 command: ["sh", "-c", "sleep 5",]
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds.nats }}
       volumes:
         - name: data
           emptyDir: {}

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -625,7 +625,7 @@ spec:
               name: {{ include "bindplane.fullname" . }}-prometheus-data
         {{- end }}
         {{- end }}
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds.bindplane }}
       volumes:
         {{- if eq .Values.eventbus.type "pubsub" }}
         {{- if .Values.eventbus.pubsub.credentials.secret }}

--- a/charts/bindplane/templates/prometheus.yaml
+++ b/charts/bindplane/templates/prometheus.yaml
@@ -119,6 +119,7 @@ spec:
             - mountPath: /etc/prometheus/web.yml
               subPath: web.yml
               name: config
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds.prometheus }}
       volumes:
         - name: config
           configMap:

--- a/charts/bindplane/templates/transform-agent.yaml
+++ b/charts/bindplane/templates/transform-agent.yaml
@@ -74,4 +74,4 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds.transform_agent }}

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -461,6 +461,20 @@ priorityClassName:
   # -- This is for configuring spec.template.spec.priorityClassName on the BindPlane transform agent pod.
   transform_agent: ""
 
+# -- Configure the terminationGracePeriodSeconds for BindPlane, BindPlane NATS, BindPlane Jobs, and BindPlane Prometheus pods.
+terminationGracePeriodSeconds:
+  # -- This is for configuring spec.template.spec.terminationGracePeriodSeconds on the BindPlane deployment pods.
+  bindplane: 60
+  # -- This is for configuring spec.template.spec.terminationGracePeriodSeconds on the BindPlane NATS statefulset or deployment
+  # pods, if NATS is enabled.
+  nats: 60
+  # -- This is for configuring spec.template.spec.terminationGracePeriodSeconds on the BindPlane Jobs pod.
+  jobs: 60
+  # -- This is for configuring spec.template.spec.terminationGracePeriodSeconds on the BindPlane Prometheus pod.
+  prometheus: 60
+  # -- This is for configuring spec.template.spec.terminationGracePeriodSeconds on the BindPlane transform agent pod.
+  transform_agent: 60
+
 # -- Configure the nodeSelector for BindPlane, BindPlane NATS, BindPlane Jobs, and BindPlane Prometheus pods.
 nodeSelector:
   # -- This is for configuring spec.template.spec.nodeSelector on the BindPlane deployment pod when using the bbolt backend.

--- a/test/cases/all/values.yaml
+++ b/test/cases/all/values.yaml
@@ -179,3 +179,10 @@ priorityClassName:
   jobs: "high-priority"
   prometheus: "high-priority"
   transform_agent: "high-priority"
+
+terminationGracePeriodSeconds:
+  bindplane: 30
+  nats: 31
+  jobs: 32
+  prometheus: 33
+  transform_agent: 34


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Similar to https://github.com/observIQ/bindplane-op-helm/pull/181, adds support for configuring terminationGracePeriodSeconds for all deployments.

## Testing

I deployed BindPlane HA w/ NATs.

After adding the following to my values and re-deploying

```yaml
terminationGracePeriodSeconds:
  bindplane: 30
  nats: 31
  jobs: 32
  prometheus: 33
  transform_agent: 34
```

I see this

```
    terminationGracePeriodSeconds: 30
    terminationGracePeriodSeconds: 32
    terminationGracePeriodSeconds: 31
    terminationGracePeriodSeconds: 31
    terminationGracePeriodSeconds: 31
    terminationGracePeriodSeconds: 33
    terminationGracePeriodSeconds: 34
```


## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
- [ ] Changes to ports, services, or other networking have been tested with **istio**
