### PR TITLE
fix: Remove svc.cluster.local fqdn assumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ You should be able to issue commands: `bindplanectl get agent`
 Collectors running within the cluster can connect with the following OpAMP URI:
 
 ```
-ws://bindplane.default.svc.cluster.local:3001/v1/opamp
+ws://bindplane.default:3001/v1/opamp
 ```
 
 # Community

--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an observability pipeline.
 type: application
 # The chart's version
-version: 1.22.0
+version: 1.22.1
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.84.0

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 1.22.0](https://img.shields.io/badge/Version-1.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.84.0](https://img.shields.io/badge/AppVersion-1.84.0-informational?style=flat-square)
+![Version: 1.22.1](https://img.shields.io/badge/Version-1.22.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.84.0](https://img.shields.io/badge/AppVersion-1.84.0-informational?style=flat-square)
 
 BindPlane OP is an observability pipeline.
 

--- a/charts/bindplane/templates/bindplane-jobs.yaml
+++ b/charts/bindplane/templates/bindplane-jobs.yaml
@@ -132,7 +132,7 @@ spec:
               {{- if .Values.config.server_url }}
               value: {{ .Values.config.server_url }}
               {{- else }}
-              value: http://{{ include "bindplane.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:3001
+              value: http://{{ include "bindplane.fullname" . }}.{{ .Release.Namespace }}:3001
               {{- end }}
             {{ if eq .Values.auth.type "system" }}
             - name: BINDPLANE_USERNAME
@@ -305,7 +305,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: BINDPLANE_NATS_CLIENT_ENDPOINT
-              value: nats://{{ include "bindplane.fullname" . }}-nats-headless.{{ .Release.Namespace }}.svc.cluster.local:4222
+              value: nats://{{ include "bindplane.fullname" . }}-nats-headless.{{ .Release.Namespace }}:4222
             - name: BINDPLANE_NATS_CLIENT_SUBJECT
               value: bindplane-event-bus
             {{- end }}

--- a/charts/bindplane/templates/bindplane-nats.yaml
+++ b/charts/bindplane/templates/bindplane-nats.yaml
@@ -112,7 +112,7 @@ spec:
               {{- if .Values.config.server_url }}
               value: {{ .Values.config.server_url }}
               {{- else }}
-              value: http://{{ include "bindplane.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:3001
+              value: http://{{ include "bindplane.fullname" . }}.{{ .Release.Namespace }}:3001
               {{- end }}
             {{ if eq .Values.auth.type "system" }}
             - name: BINDPLANE_USERNAME
@@ -188,10 +188,10 @@ spec:
               value: "6222"
             - name: BINDPLANE_NATS_SERVER_CLUSTER_ROUTES
               {{ if eq .Values.nats.deploymentType "StatefulSet" }}
-              value: nats://{{ include "bindplane.fullname" . }}-nats-0.{{ include "bindplane.fullname" . }}-nats-cluster-headless.{{ .Release.Namespace }}.svc.cluster.local:6222,nats://{{ include "bindplane.fullname" . }}-nats-1.{{ include "bindplane.fullname" . }}-nats-cluster-headless.{{ .Release.Namespace }}.svc.cluster.local:6222,nats://{{ include "bindplane.fullname" . }}-nats-2.{{ include "bindplane.fullname" . }}-nats-cluster-headless.{{ .Release.Namespace }}.svc.cluster.local:6222
+              value: nats://{{ include "bindplane.fullname" . }}-nats-0.{{ include "bindplane.fullname" . }}-nats-cluster-headless.{{ .Release.Namespace }}:6222,nats://{{ include "bindplane.fullname" . }}-nats-1.{{ include "bindplane.fullname" . }}-nats-cluster-headless.{{ .Release.Namespace }}:6222,nats://{{ include "bindplane.fullname" . }}-nats-2.{{ include "bindplane.fullname" . }}-nats-cluster-headless.{{ .Release.Namespace }}:6222
               {{ end }}
               {{ if eq .Values.nats.deploymentType "Deployment" }}
-              value: nats://{{ include "bindplane.fullname" . }}-nats-cluster-headless.{{ .Release.Namespace }}.svc.cluster.local:6222
+              value: nats://{{ include "bindplane.fullname" . }}-nats-cluster-headless.{{ .Release.Namespace }}:6222
               {{ end }}
             - name: BINDPLANE_NATS_CLIENT_NAME
               valueFrom:

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -161,7 +161,7 @@ spec:
               {{- if .Values.config.server_url }}
               value: {{ .Values.config.server_url }}
               {{- else }}
-              value: http://{{ include "bindplane.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:3001
+              value: http://{{ include "bindplane.fullname" . }}.{{ .Release.Namespace }}:3001
               {{- end }}
             {{ if eq .Values.auth.type "system" }}
             - name: BINDPLANE_USERNAME
@@ -334,7 +334,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: BINDPLANE_NATS_CLIENT_ENDPOINT
-              value: nats://{{ include "bindplane.fullname" . }}-nats-headless.{{ .Release.Namespace }}.svc.cluster.local:4222
+              value: nats://{{ include "bindplane.fullname" . }}-nats-headless.{{ .Release.Namespace }}:4222
             - name: BINDPLANE_NATS_CLIENT_SUBJECT
               value: bindplane-event-bus
             {{- end }}


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

The chart assumes the cluster's service FQDN will be `.svc.cluster.local`. Generally this is true, but not always. It is also unnecessary. Services can look each other up by quering the service name or service name and namespace.

```
$ kubectl get service -n default

NAME                                 TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
bindplane-ha                         ClusterIP   10.96.110.178   <none>        3001/TCP   11m
bindplane-ha-nats-cluster-headless   ClusterIP   None            <none>        6222/TCP   11m
bindplane-ha-nats-headless           ClusterIP   None            <none>        4222/TCP   11m
bindplane-ha-prometheus              ClusterIP   10.103.27.175   <none>        9090/TCP   11m
bindplane-ha-transform-agent         ClusterIP   10.103.162.9    <none>        4568/TCP   11m
kubernetes                           ClusterIP   10.96.0.1       <none>        443/TCP    46m
```

The `bindplane-ha-nats-cluster-headless` service can be looked up with the following:
- `bindplane-ha-nats-cluster-headless`
- `bindplane-ha-nats-cluster-headless.default` (We are deployed to namespace `default`)
- `bindplane-ha-nats-cluster-headless.default.svc.cluster.local`

This PR removes the cluster fqdn suffix but retains the namespace in all service names. This is backwards compatible as the chart deploys all services to the same namespace. Any systems outside of the namespace (agents) can continue using the generated remote url, which defaults to `<Helm deployment name>.<namespace>`.

## Testing

I deployed the chart without setting `server_url`. This causes the default remote url to be `ws://bindplane-ha.default:3001/v1/opamp`.

When I install a k8s agent, the env looks like this and agents connect without issue.

```yaml
          env:
            - name: OPAMP_ENDPOINT
              value: ws://bindplane-ha.default:3001/v1/opamp
```

I verified connectivity to the following:
- Prometheus: measurements are working
- Transform agent: live preview is working
- NATS: Rollouts, live preview, and recently telemetry are working

![Screenshot from 2024-11-26 14-33-23](https://github.com/user-attachments/assets/194838dc-7dce-465a-b19c-8535f0697920)


## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
- [ ] Changes to ports, services, or other networking have been tested with **istio**
