### PR TITLE
fix: Skip mounting Postgres TLS certificats from secret when sslSource is 'manual'

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an observability pipeline.
 type: application
 # The chart's version
-version: 1.23.0
+version: 1.23.1
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.84.0

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 1.23.0](https://img.shields.io/badge/Version-1.23.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.84.0](https://img.shields.io/badge/AppVersion-1.84.0-informational?style=flat-square)
+![Version: 1.23.1](https://img.shields.io/badge/Version-1.23.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.84.0](https://img.shields.io/badge/AppVersion-1.84.0-informational?style=flat-square)
 
 BindPlane OP is an observability pipeline.
 

--- a/charts/bindplane/templates/bindplane-jobs.yaml
+++ b/charts/bindplane/templates/bindplane-jobs.yaml
@@ -613,10 +613,12 @@ spec:
         {{- if .Values.backend.postgres.sslsecret.name }}
         - name: postgres-tls-dir
           emptyDir: {}
+        {{- if eq .Values.backend.postgres.sslSource "secret" }}
         - name: {{ .Values.backend.postgres.sslsecret.name }}
           secret:
             defaultMode: 0400
             secretName: {{ .Values.backend.postgres.sslsecret.name }}
+        {{- end }}
         - name: postgres-tls-init
           configMap:
             name: postgres-tls-init

--- a/charts/bindplane/templates/bindplane-jobs.yaml
+++ b/charts/bindplane/templates/bindplane-jobs.yaml
@@ -60,7 +60,6 @@ spec:
       {{- toYaml .Values.topologySpreadConstraints.jobs | nindent 8 }}
       {{- end }}
       {{- if .Values.backend.postgres.sslsecret.name }}
-      {{- if eq .Values.backend.postgres.sslSource "secret" }}
       initContainers:
         - name: postgres-tls
           image: {{ .Values.busybox_image }}
@@ -74,6 +73,7 @@ spec:
               subPath: init.sh
             - mountPath: /postgres-tls
               name: postgres-tls-dir
+            {{- if eq .Values.backend.postgres.sslSource "secret" }}
             {{- if .Values.backend.postgres.sslsecret.sslrootcertSubPath }}
             - mountPath: /ca.crt
               name: {{ .Values.backend.postgres.sslsecret.name }}
@@ -87,7 +87,7 @@ spec:
               name: {{ .Values.backend.postgres.sslsecret.name }}
               subPath: {{ .Values.backend.postgres.sslsecret.sslkeySubPath }}
             {{- end }}
-      {{- end }}
+            {{- end }}
       {{- end }}
       containers:
         - name: server

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -86,7 +86,6 @@ spec:
               mountPath: /data
       {{- end }}
       {{- if .Values.backend.postgres.sslsecret.name }}
-      {{- if eq .Values.backend.postgres.sslSource "secret" }}
         - name: postgres-tls
           image: {{ .Values.busybox_image }}
           command:
@@ -99,6 +98,7 @@ spec:
               subPath: init.sh
             - mountPath: /postgres-tls
               name: postgres-tls-dir
+            {{- if eq .Values.backend.postgres.sslSource "secret" }}
             {{- if .Values.backend.postgres.sslsecret.sslrootcertSubPath }}
             - mountPath: /ca.crt
               name: {{ .Values.backend.postgres.sslsecret.name }}
@@ -112,7 +112,7 @@ spec:
               name: {{ .Values.backend.postgres.sslsecret.name }}
               subPath: {{ .Values.backend.postgres.sslsecret.sslkeySubPath }}
             {{- end }}
-      {{- end }}
+            {{- end }}
       {{- end }}
       containers:
         - name: server

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -671,10 +671,12 @@ spec:
         {{- if .Values.backend.postgres.sslsecret.name }}
         - name: postgres-tls-dir
           emptyDir: {}
+        {{- if eq .Values.backend.postgres.sslSource "secret" }}
         - name: {{ .Values.backend.postgres.sslsecret.name }}
           secret:
             defaultMode: 0400
             secretName: {{ .Values.backend.postgres.sslsecret.name }}
+        {{- end }}
         - name: postgres-tls-init
           configMap:
             name: postgres-tls-init

--- a/charts/bindplane/templates/configmap.yaml
+++ b/charts/bindplane/templates/configmap.yaml
@@ -19,7 +19,7 @@ data:
     #!/bin/sh
 {{- if eq .Values.backend.postgres.sslSource "secret" }}
     cp /ca.crt /client.crt /client.key /postgres-tls
-    chmod 0400 /postgres-tls/*
 {{- end }}
+    chmod 0400 /postgres-tls/*
     chown -R 65534:65534 /postgres-tls
 {{ end }}

--- a/charts/bindplane/templates/configmap.yaml
+++ b/charts/bindplane/templates/configmap.yaml
@@ -10,7 +10,6 @@ data:
     chmod 0750 /data
 {{ end }}
 {{- if .Values.backend.postgres.sslsecret.name }}
-{{- if eq .Values.backend.postgres.sslSource "secret" }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -18,8 +17,9 @@ metadata:
 data:
   init.sh: |
     #!/bin/sh
+{{- if eq .Values.backend.postgres.sslSource "secret" }}
     cp /ca.crt /client.crt /client.key /postgres-tls
     chmod 0400 /postgres-tls/*
+{{- end }}
     chown -R 65534:65534 /postgres-tls
-{{ end }}
 {{ end }}


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

When Postgres sslSource is not "source", the config map for initializing the Postgres TLS emptydir volume should still be used, but it should skip copying the files from the secret to the emptyDir.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
- [ ] Changes to ports, services, or other networking have been tested with **istio**
