### PR TITLE
feat: Optional arbitrary init containers

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an observability pipeline.
 type: application
 # The chart's version
-version: 1.23.1
+version: 1.24.0
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.84.0

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 1.23.1](https://img.shields.io/badge/Version-1.23.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.84.0](https://img.shields.io/badge/AppVersion-1.84.0-informational?style=flat-square)
+![Version: 1.24.0](https://img.shields.io/badge/Version-1.24.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.84.0](https://img.shields.io/badge/AppVersion-1.84.0-informational?style=flat-square)
 
 BindPlane OP is an observability pipeline.
 
@@ -97,6 +97,7 @@ BindPlane OP is an observability pipeline.
 | eventbus.pubsub.topic | string | `""` |  |
 | eventbus.type | string | `""` |  |
 | extraEnv | list | `[]` | Optional arbitrary environment variables to add to the BindPlane pod(s). |
+| extraInitContainers | object | `{"bindplane":[],"jobs":[],"nats":[],"prometheus":[],"transform_agent":[]}` | Optional arbitrary init containers. |
 | extraPodLabels | object | `{}` | Optional arbitrary labels to add to the BindPlane pod(s). |
 | extraVolumeMounts | list | `[]` | Optional arbitrary volume mounts to add to the BindPlane pod(s). |
 | extraVolumes | list | `[]` | Optional arbitrary volumes to add to the BindPlane pod(s). |

--- a/charts/bindplane/templates/bindplane-jobs.yaml
+++ b/charts/bindplane/templates/bindplane-jobs.yaml
@@ -59,8 +59,8 @@ spec:
       topologySpreadConstraints:
       {{- toYaml .Values.topologySpreadConstraints.jobs | nindent 8 }}
       {{- end }}
-      {{- if .Values.backend.postgres.sslsecret.name }}
       initContainers:
+        {{- if .Values.backend.postgres.sslsecret.name }}
         - name: postgres-tls
           image: {{ .Values.busybox_image }}
           command:
@@ -88,7 +88,10 @@ spec:
               subPath: {{ .Values.backend.postgres.sslsecret.sslkeySubPath }}
             {{- end }}
             {{- end }}
-      {{- end }}
+        {{- end }}
+        {{- if .Values.extraInitContainers.nats }}
+          {{- toYaml .Values.extraInitContainers.nats | nindent 8 }}
+        {{- end }}
       containers:
         - name: server
           image: {{ include "bindplane.image" . }}:{{ include "bindplane.tag" . }}

--- a/charts/bindplane/templates/bindplane-jobs.yaml
+++ b/charts/bindplane/templates/bindplane-jobs.yaml
@@ -89,8 +89,8 @@ spec:
             {{- end }}
             {{- end }}
         {{- end }}
-        {{- if .Values.extraInitContainers.nats }}
-          {{- toYaml .Values.extraInitContainers.nats | nindent 8 }}
+        {{- if .Values.extraInitContainers.jobs }}
+          {{- toYaml .Values.extraInitContainers.jobs | nindent 8 }}
         {{- end }}
       containers:
         - name: server

--- a/charts/bindplane/templates/bindplane-nats.yaml
+++ b/charts/bindplane/templates/bindplane-nats.yaml
@@ -63,6 +63,10 @@ spec:
       topologySpreadConstraints:
       {{- toYaml .Values.topologySpreadConstraints.nats | nindent 8 }}
       {{- end }}
+      initContainers:
+      {{- if .Values.extraInitContainers.nats }}
+        {{- toYaml .Values.extraInitContainers.nats | nindent 8 }}
+      {{- end }}
       containers:
         - name: server
           image: {{ include "bindplane.image" . }}:{{ include "bindplane.tag" . }}

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -114,6 +114,9 @@ spec:
             {{- end }}
             {{- end }}
       {{- end }}
+      {{- if .Values.extraInitContainers.bindplane }}
+        {{- toYaml .Values.extraInitContainers.bindplane | nindent 8 }}
+      {{- end }}
       containers:
         - name: server
           image: {{ include "bindplane.image" . }}:{{ include "bindplane.tag" . }}

--- a/charts/bindplane/templates/prometheus.yaml
+++ b/charts/bindplane/templates/prometheus.yaml
@@ -79,6 +79,10 @@ spec:
       topologySpreadConstraints:
       {{- toYaml .Values.topologySpreadConstraints.prometheus | nindent 8 }}
       {{- end }}
+      initContainers:
+      {{- if .Values.extraInitContainers.prometheus }}
+        {{- toYaml .Values.extraInitContainers.prometheus | nindent 8 }}
+      {{- end }}
       containers:
         - name: prometheus
           image: {{ .Values.prometheus.image.name }}:{{ .Values.prometheus.image.tag }}

--- a/charts/bindplane/templates/transform-agent.yaml
+++ b/charts/bindplane/templates/transform-agent.yaml
@@ -47,6 +47,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      initContainers:
+      {{- if .Values.extraInitContainers.transform_agent }}
+        {{- toYaml .Values.extraInitContainers.transform_agent | nindent 8 }}
+      {{- end }}
       containers:
         - name: transform-agent
           image: {{ include "bindplane.transform_agent" . }}:{{ include "bindplane.transform_agent_tag" . }}

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -595,3 +595,11 @@ extraEnv: []
 
 # -- The container image to use for the busybox init container.
 busybox_image: busybox:latest
+
+# -- Optional arbitrary init containers.
+extraInitContainers:
+  bindplane: []
+  nats: []
+  jobs: []
+  prometheus: []
+  transform_agent: []

--- a/test/cases/nats/values.yaml
+++ b/test/cases/nats/values.yaml
@@ -53,3 +53,25 @@ nats:
 
 metrics:
   type: prometheus
+
+extraInitContainers:
+  bindplane:
+    - name: busy-box-test-bindplane
+      image: busybox:latest
+      command: ['sh', '-c', 'echo hello']
+  nats:
+    - name: busy-box-test-nats
+      image: busybox:latest
+      command: ['sh', '-c', 'echo hello']
+  jobs:
+    - name: busy-box-test-jobs
+      image: busybox:latest
+      command: ['sh', '-c', 'echo hello']
+  prometheus:
+    - name: busy-box-test-prometheus
+      image: busybox:latest
+      command: ['sh', '-c', 'echo hello']
+  transform_agent:
+    - name: busy-box-test-transform-agent
+      image: busybox:latest
+      command: ['sh', '-c', 'echo hello']


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Added support for initContainers. Each deployment has its own section. See the change to `test/cases/nats/values.yaml` for an example.

Init containers will allow users to perform custom actions before starting each service. Most users will not rely on this feature, it is for more advanced use-cases or testing.

e.g. I will be using this feature for generating certificates at startup, using `openssl`. 

## Testing

I updated `test/cases/nats/values.yaml` to deploy initContainers. Working great. Each pod has its own basic init container.

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
- [ ] Changes to ports, services, or other networking have been tested with **istio**
