### PR TITLE
feat: Expose command and args

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,10 +3,10 @@ name: bindplane
 description: BindPlane OP is an observability pipeline.
 type: application
 # The chart's version
-version: 1.25.0
+version: 1.26.0
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
-appVersion: 1.84.0
+appVersion: 1.84.1
 keywords:
   - kubernetes
   - bindplane

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 1.25.0](https://img.shields.io/badge/Version-1.25.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.84.0](https://img.shields.io/badge/AppVersion-1.84.0-informational?style=flat-square)
+![Version: 1.26.0](https://img.shields.io/badge/Version-1.26.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.84.1](https://img.shields.io/badge/AppVersion-1.84.1-informational?style=flat-square)
 
 BindPlane OP is an observability pipeline.
 
@@ -23,6 +23,7 @@ BindPlane OP is an observability pipeline.
 | affinity.nats | object | `{}` | This is for configuring spec.template.spec.affinity on the BindPlane NATS statefulset or deployment pods, if NATS is enabled. |
 | affinity.prometheus | object | `{}` | This is for configuring spec.template.spec.affinity on the BindPlane Prometheus pod. |
 | affinity.transform_agent | object | `{}` | This is for configuring spec.template.spec.affinity on the BindPlane transform agent pod. |
+| args | list | `[]` | Optional arguments overrides for the BindPlane container in all BindPlane pods. |
 | auth.google.clientid | string | `""` | Google OAUTH clientid |
 | auth.ldap.baseDN | string | `""` | Base DN to use when looking up users. Example: `ou=users,dc=stage,dc=net`. |
 | auth.ldap.bindCredentialSecret.name | string | `""` | Kubernetes secret name that contains the bind username and password. |
@@ -70,6 +71,7 @@ BindPlane OP is an observability pipeline.
 | backend.postgres.username | string | `""` | Username to use when connecting to Postgres. |
 | backend.type | string | `"bbolt"` | Backend to use for persistent storage. Available options are `bbolt`, and `postgres`. |
 | busybox_image | string | `"busybox:latest"` | The container image to use for the busybox init container. |
+| command | list | `[]` | Optional command overrides for the BindPlane container in all BindPlane pods. |
 | config.accept_eula | bool | `true` | Whether or not to accept the EULA. EULA acceptance is required. See https://observiq.com/legal/eula. |
 | config.analytics.disable | bool | `false` | Whether or not to disable analytics. Disabling analytics is only supported when an enterprise license is used. |
 | config.license | string | `""` | The license key to use for BindPlane OP. Overrides `config.secret`. |

--- a/charts/bindplane/templates/bindplane-jobs.yaml
+++ b/charts/bindplane/templates/bindplane-jobs.yaml
@@ -65,6 +65,12 @@ spec:
         {{- end }}
       containers:
         - name: server
+          {{ - if .Values.command }}
+          command: {{ .Values.command }}
+          {{- end }}
+          {{ - if .Values.args }}
+          args: {{ .Values.args }}
+          {{- end }}
           image: {{ include "bindplane.image" . }}:{{ include "bindplane.tag" . }}
           imagePullPolicy: IfNotPresent
           ports:

--- a/charts/bindplane/templates/bindplane-jobs.yaml
+++ b/charts/bindplane/templates/bindplane-jobs.yaml
@@ -65,11 +65,13 @@ spec:
         {{- end }}
       containers:
         - name: server
-          {{ - if .Values.command }}
-          command: {{ .Values.command }}
+          {{- with .Values.command }}
+          command:
+          {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{ - if .Values.args }}
-          args: {{ .Values.args }}
+          {{- with .Values.args }}
+          args:
+          {{- toYaml . | nindent 12 }}
           {{- end }}
           image: {{ include "bindplane.image" . }}:{{ include "bindplane.tag" . }}
           imagePullPolicy: IfNotPresent

--- a/charts/bindplane/templates/bindplane-nats.yaml
+++ b/charts/bindplane/templates/bindplane-nats.yaml
@@ -69,11 +69,13 @@ spec:
       {{- end }}
       containers:
         - name: server
-          {{ - if .Values.command }}
-          command: {{ .Values.command }}
+          {{- with .Values.command }}
+          command:
+          {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{ - if .Values.args }}
-          args: {{ .Values.args }}
+          {{- with .Values.args }}
+          args:
+          {{- toYaml . | nindent 12 }}
           {{- end }}
           image: {{ include "bindplane.image" . }}:{{ include "bindplane.tag" . }}
           imagePullPolicy: IfNotPresent

--- a/charts/bindplane/templates/bindplane-nats.yaml
+++ b/charts/bindplane/templates/bindplane-nats.yaml
@@ -69,6 +69,12 @@ spec:
       {{- end }}
       containers:
         - name: server
+          {{ - if .Values.command }}
+          command: {{ .Values.command }}
+          {{- end }}
+          {{ - if .Values.args }}
+          args: {{ .Values.args }}
+          {{- end }}
           image: {{ include "bindplane.image" . }}:{{ include "bindplane.tag" . }}
           imagePullPolicy: IfNotPresent
           ports:

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -76,6 +76,12 @@ spec:
       {{- end }}
       containers:
         - name: server
+          {{ - if .Values.command }}
+          command: {{ .Values.command }}
+          {{- end }}
+          {{ - if .Values.args }}
+          args: {{ .Values.args }}
+          {{- end }}
           image: {{ include "bindplane.image" . }}:{{ include "bindplane.tag" . }}
           imagePullPolicy: IfNotPresent
           ports:

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -76,11 +76,13 @@ spec:
       {{- end }}
       containers:
         - name: server
-          {{ - if .Values.command }}
-          command: {{ .Values.command }}
+          {{- with .Values.command }}
+          command:
+          {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{ - if .Values.args }}
-          args: {{ .Values.args }}
+          {{- with .Values.args }}
+          args:
+          {{- toYaml . | nindent 12 }}
           {{- end }}
           image: {{ include "bindplane.image" . }}:{{ include "bindplane.tag" . }}
           imagePullPolicy: IfNotPresent

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -605,3 +605,11 @@ extraInitContainers:
   jobs: []
   prometheus: []
   transform_agent: []
+
+# -- Optional command overrides for the BindPlane container in all
+# BindPlane pods.
+command: []
+
+# -- Optional arguments overrides for the BindPlane container in all
+# BindPlane pods.
+args: []

--- a/test/cases/all/values.yaml
+++ b/test/cases/all/values.yaml
@@ -186,3 +186,12 @@ terminationGracePeriodSeconds:
   jobs: 32
   prometheus: 33
   transform_agent: 34
+
+command:
+  - /bindplane
+  - serve
+
+args:
+  - --logging-level
+  - debug
+


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Added `command: []` and `args: []` options to the Values file, for overriding the default command and args. This is usefulf or users who need to pass flags to the BindPlane process.

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
- [ ] Changes to ports, services, or other networking have been tested with **istio**

1. Deployed latest chart version, observed `command` and `args` not set
2. Upgraded to this branch without configuring the new options, observed `command` and `args` not set
3. Configured `command` to `["/bindplane","serve"], left `args unconfigured, observed that `command` was set and the pods were running
4. Added `args` with `["--config", "/etc/bindplane/config.yaml"]` and observed `args` was set and the new pods **failed** to start, because /etc/bindplane/config.yaml does not exist (expected failure)
5. Removed `command` and `args` and observed the deployment going back to working
