### PR TITLE
feat: Transform Agent extra pod labels

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an observability pipeline.
 type: application
 # The chart's version
-version: 1.26.1
+version: 1.26.2
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.84.2

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 1.26.1](https://img.shields.io/badge/Version-1.26.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.84.2](https://img.shields.io/badge/AppVersion-1.84.2-informational?style=flat-square)
+![Version: 1.26.2](https://img.shields.io/badge/Version-1.26.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.84.2](https://img.shields.io/badge/AppVersion-1.84.2-informational?style=flat-square)
 
 BindPlane OP is an observability pipeline.
 
@@ -186,6 +186,7 @@ BindPlane OP is an observability pipeline.
 | trace.otlp.insecure | bool | `false` | Set to `true` to disable TLS. Set to false if TLS is in use by the OTLP trace receiver. |
 | trace.otlp.samplingRate | string | `"1"` | Sampling rate between 0 and 1. 1 being 100% of traces are sent. |
 | trace.type | string | `""` | Trace type to use. Valid options include `otlp`. |
+| transform_agent.extraPodLabels | object | `{}` | Optional arbitrary labels to add to the Transform Agent pods. |
 | transform_agent.name | string | `""` | Transform Agent Image name to be used. Defaults to `ghcr.io/observiq/bindplane-transform-agent`. |
 | transform_agent.replicas | int | `1` | Number of replicas to use for the transform agent. |
 | transform_agent.tag | string | `""` | Transform Agent Image tag to use. Defaults to latest. |

--- a/charts/bindplane/templates/transform-agent.yaml
+++ b/charts/bindplane/templates/transform-agent.yaml
@@ -24,6 +24,9 @@ spec:
         app.kubernetes.io/stack: bindplane
         app.kubernetes.io/component: transform-agent
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- if len .Values.transform_agent.extraPodLabels }}
+        {{- toYaml .Values.transform_agent.extraPodLabels | nindent 8 }}
+        {{- end }}
     spec:
       priorityClassName: {{ .Values.priorityClassName.transform_agent }}
       {{- if .Values.nodeSelector.transform_agent }}

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -276,6 +276,8 @@ transform_agent:
   tag: ""
   # -- Number of replicas to use for the transform agent.
   replicas: 1
+  # -- Optional arbitrary labels to add to the Transform Agent pods.
+  extraPodLabels: {}
 
 # Bindplane configuration options:
 # https://github.com/observIQ/bindplane-op/blob/main/docs/configuration.md


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

The chart supports `extraPodLabels` for Bindplane and Prometheus pods, but not Transform Agent. This PR addresses that. The transform agent extra labels are implemented the same as Bindplane / Prometheus.

## Testing

I included this config snippet in my values file.

```yaml
transform_agent:
  extraPodLabels:
    user: joe
    repo: bindplane-op-helm
```

When inspecting the deployed transform agent pod, I see the following labels. The last two are the extra labels added by the values file.

```yaml
apiVersion: v1
kind: Pod
metadata:
  labels:
    app.kubernetes.io/component: transform-agent
    app.kubernetes.io/instance: bindplane
    app.kubernetes.io/name: bindplane-transform-agent
    app.kubernetes.io/stack: bindplane
    pod-template-hash: 74cb87887d
    repo: bindplane-op-helm
    user: joe
```


## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
- [ ] Changes to ports, services, or other networking have been tested with **istio**
