### PR TITLE
chore: Mark bbolt as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,19 @@
 
 # BindPlane OP Helm
 
-This repository contains a Helm chart for [BindPlane OP](https://github.com/observIQ/bindplane-op).
+This repository contains a Helm chart for [BindPlane OP](https://observ-iq-next-git-joesiri-92ee87-jj-observ-iqp-ixel-point-team.vercel.app/).
 
 ## Prerequisites
+
+### Postgres
+
+BindPlane supports two backend storage options. Postgres and `bbolt` (deprecated). The chart will
+use `bbolt` by default, however, Bindplane recommends using Postgres for production deployments. Additionally,
+the `bbolt` backend will be removed in BindPlane version 2. Postgres allows for better performance and
+scalability. BindPlane with High Availability requires Postgres.
+
+See the BindPlane [PostgreSQL documentation](https://bindplane.com/docs/advanced-setup/installation/postgresql)
+for more details.
 
 ### Helm
 

--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: BindPlane OP is an observability pipeline.
 type: application
 # The chart's version
-version: 1.26.4
+version: 1.26.5
 # The BindPlane OP tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.86.0

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 1.26.4](https://img.shields.io/badge/Version-1.26.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.86.0](https://img.shields.io/badge/AppVersion-1.86.0-informational?style=flat-square)
+![Version: 1.26.5](https://img.shields.io/badge/Version-1.26.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.86.0](https://img.shields.io/badge/AppVersion-1.86.0-informational?style=flat-square)
 
 BindPlane OP is an observability pipeline.
 

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -69,7 +69,7 @@ BindPlane OP is an observability pipeline.
 | backend.postgres.sslsecret.sslkeySubPath | string | `"client.key"` | Path to the client private key used to authenticate with the Postgres server, when mutual TLS is required. Required when `sslcertSubPath` is set. |
 | backend.postgres.sslsecret.sslrootcertSubPath | string | `"ca.crt"` | Path to the CA certificate used to verify the Postgres server's certificate. |
 | backend.postgres.username | string | `""` | Username to use when connecting to Postgres. |
-| backend.type | string | `"bbolt"` | Backend to use for persistent storage. Available options are `bbolt`, and `postgres`. |
+| backend.type | string | `"bbolt"` | Backend to use for persistent storage. Available options are `bbolt` (deprecated), and `postgres`. |
 | busybox_image | string | `"busybox:latest"` | The container image to use for the busybox init container. |
 | command | list | `[]` | Optional command overrides for the BindPlane container in all BindPlane pods. |
 | config.accept_eula | bool | `true` | Whether or not to accept the EULA. EULA acceptance is required. See https://observiq.com/legal/eula. |

--- a/charts/bindplane/values.schema.json
+++ b/charts/bindplane/values.schema.json
@@ -2,6 +2,15 @@
   "$schema": "http://json-schema.org/schema#",
   "type": "object",
   "properties": {
+    "backend": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["postgres", "bbolt"]
+        }
+      }
+    },
     "nats": {
       "type": "object",
       "properties": {

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -2,9 +2,10 @@
 multiAccount: false
 
 backend:
-  # -- Backend to use for persistent storage. Available options are `bbolt`, and `postgres`.
+  # -- Backend to use for persistent storage. Available options are `bbolt` (deprecated), and `postgres`.
   type: bbolt
 
+  # bbolt is deprecated and will be removed in a future release.
   bbolt:
     # -- Persistent volume size.
     volumeSize: 10Gi


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Updated documentation to mention that bbolt is deprecated. Bindplane v2 will use Postgres exclusively.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
- [ ] Changes to ports, services, or other networking have been tested with **istio**
