### PR TITLE
feat: Custom service account annotations

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: Bindplane is an observability pipeline.
 type: application
 # The chart's version
-version: 1.26.6
+version: 1.27.0
 # The Bindplane tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.86.0

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 1.26.6](https://img.shields.io/badge/Version-1.26.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.86.0](https://img.shields.io/badge/AppVersion-1.86.0-informational?style=flat-square)
+![Version: 1.27.0](https://img.shields.io/badge/Version-1.27.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.86.0](https://img.shields.io/badge/AppVersion-1.86.0-informational?style=flat-square)
 
 Bindplane is an observability pipeline.
 
@@ -170,6 +170,7 @@ Bindplane is an observability pipeline.
 | resources.requests.cpu | string | `"1000m"` | CPU request. |
 | resources.requests.memory | string | `"1000Mi"` | Memory request. |
 | service.annotations | object | `{}` | Custom annotations which will be added to the service object. Useful for specifying things such as `cloud.google.com/backend-config`. |
+| serviceAccount.annotations | object | `{}` | Optional annotations to add to the service account. |
 | terminationGracePeriodSeconds | object | `{"bindplane":60,"jobs":60,"nats":60,"prometheus":60,"transform_agent":60}` | Configure the terminationGracePeriodSeconds for Bindplane, Bindplane NATS, Bindplane Jobs, and Bindplane Prometheus pods. |
 | terminationGracePeriodSeconds.bindplane | int | `60` | This is for configuring spec.template.spec.terminationGracePeriodSeconds on the Bindplane deployment pods. |
 | terminationGracePeriodSeconds.jobs | int | `60` | This is for configuring spec.template.spec.terminationGracePeriodSeconds on the Bindplane Jobs pod. |

--- a/charts/bindplane/templates/service-account.yml
+++ b/charts/bindplane/templates/service-account.yml
@@ -8,3 +8,7 @@ metadata:
     app.kubernetes.io/stack: bindplane
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    {{- if .Values.serviceAccount.annotations }}
+    {{ toYaml .Values.serviceAccount.annotations }}
+    {{- end }}

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -616,3 +616,7 @@ command: []
 # -- Optional arguments overrides for the Bindplane container in all
 # Bindplane pods.
 args: []
+
+serviceAccount:
+  # -- Optional annotations to add to the service account.
+  annotations: {}

--- a/test/cases/nats/values.yaml
+++ b/test/cases/nats/values.yaml
@@ -75,3 +75,7 @@ extraInitContainers:
     - name: busy-box-test-transform-agent
       image: busybox:latest
       command: ['sh', '-c', 'echo hello']
+
+serviceAccount:
+  annotations:
+    iam.gke.io/gcp-service-account: "bindplane-sa"


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Added support for arbitrary service account annotations.

When running `helm template` with annotations defined (see test update), I get the following service account.

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: release-name-bindplane
  namespace: default
  labels:
    app.kubernetes.io/name: bindplane
    app.kubernetes.io/stack: bindplane
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
  annotations:
    iam.gke.io/gcp-service-account: bindplane-sa
```

This annotation allows users to implement workload identity in GKE. You can read more about it here. https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity

Closes https://github.com/observIQ/bindplane-op-helm/issues/177

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
- [ ] Changes to ports, services, or other networking have been tested with **istio**
