### PR TITLE
feat(config): Support configurable agent version sync client

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: Bindplane is an observability pipeline.
 type: application
 # The chart's version
-version: 1.29.5
+version: 1.30.0
 # The Bindplane tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.92.0

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 1.29.5](https://img.shields.io/badge/Version-1.29.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.92.0](https://img.shields.io/badge/AppVersion-1.92.0-informational?style=flat-square)
+![Version: 1.30.0](https://img.shields.io/badge/Version-1.30.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.92.0](https://img.shields.io/badge/AppVersion-1.92.0-informational?style=flat-square)
 
 Bindplane is an observability pipeline.
 
@@ -73,6 +73,8 @@ Bindplane is an observability pipeline.
 | busybox_image | string | `"busybox:latest"` | The container image to use for the busybox init container. |
 | command | list | `[]` | Optional command overrides for the Bindplane container in all Bindplane pods. |
 | config.accept_eula | bool | `true` | Whether or not to accept the EULA. EULA acceptance is required. See https://observiq.com/legal/eula. |
+| config.agentVersions | object | `{"clients":["github"]}` | The agent versions clients source to use. Defaults to ["github"]. |
+| config.agentVersions.clients | list | `["github"]` | The agent version clients to use when syncing agent agent versions. Will not take effect on Bindplane versions older than v1.94.0. |
 | config.analytics.disable | bool | `false` | Whether or not to disable analytics. Disabling analytics is only supported when an enterprise license is used. |
 | config.license | string | `""` | The license key to use for Bindplane. Overrides `config.secret`. |
 | config.licenseUseSecret | bool | `false` | When true, the license key will be referenced from the `config.secret` secret. |

--- a/charts/bindplane/templates/bindplane-jobs.yaml
+++ b/charts/bindplane/templates/bindplane-jobs.yaml
@@ -110,6 +110,8 @@ spec:
             {{- end}}
             - name: BINDPLANE_ACCEPT_EULA
               value: "{{ .Values.config.accept_eula }}"
+            - name: BINDPLANE_AGENT_VERSIONS_CLIENTS
+              value: "{{ join "," .Values.config.agentVersions.clients }}"
             - name: BINDPLANE_REMOTE_URL
               {{- if .Values.config.server_url }}
               value: {{ .Values.config.server_url }}

--- a/charts/bindplane/templates/bindplane-nats.yaml
+++ b/charts/bindplane/templates/bindplane-nats.yaml
@@ -120,6 +120,8 @@ spec:
             {{- end}}
             - name: BINDPLANE_ACCEPT_EULA
               value: "{{ .Values.config.accept_eula }}"
+            - name: BINDPLANE_AGENT_VERSIONS_CLIENTS
+              value: "{{ join "," .Values.config.agentVersions.clients }}"
             - name: BINDPLANE_REMOTE_URL
               {{- if .Values.config.server_url }}
               value: {{ .Values.config.server_url }}

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -125,6 +125,8 @@ spec:
             {{- end}}
             - name: BINDPLANE_ACCEPT_EULA
               value: "{{ .Values.config.accept_eula }}"
+            - name: BINDPLANE_AGENT_VERSIONS_CLIENTS
+              value: "{{ join "," .Values.config.agentVersions.clients }}"
             - name: BINDPLANE_REMOTE_URL
               {{- if .Values.config.server_url }}
               value: {{ .Values.config.server_url }}

--- a/charts/bindplane/values.schema.json
+++ b/charts/bindplane/values.schema.json
@@ -11,6 +11,29 @@
         }
       }
     },
+    "config": {
+      "type": "object",
+      "properties": {
+        "agentVersions": {
+          "type": "object",
+          "properties": {
+            "clients": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["github", "bdot"],
+                "description": "Valid values are 'github' or 'bdot'"
+              },
+              "description": "The agent versions clients source to use. Must contain only 'github' and/or 'bdot' values.",
+              "minItems": 1,
+              "maxItems": 2,
+              "uniqueItems": true
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
     "nats": {
       "type": "object",
       "properties": {

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -286,6 +286,12 @@ config:
   # -- Whether or not to accept the EULA. EULA acceptance is required. See https://observiq.com/legal/eula.
   accept_eula: true
 
+  # -- The agent versions clients source to use. Defaults to ["github"].
+  agentVersions:
+    # -- The agent version clients to use when syncing agent agent versions. Will not take effect on Bindplane versions older than v1.94.0.
+    clients:
+      - github
+
   analytics:
     # -- Whether or not to disable analytics. Disabling analytics is only supported when an enterprise license is used.
     disable: false


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Bindplane v1.94 (unreleased) will introduce `BINDPLANE_AGENT_VERSIONS_CLIENTS` option. This config option allows the user to define their source of truth for syncing Bindplane OTEL Collector agent version releases. It will default to `github` and eventually default to `bdot`. 

Introducing this change now allows users with pre release builds to utilize the new option.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
- [ ] Changes to ports, services, or other networking have been tested with **istio**
