### PR TITLE
feat: Expose BINDPLANE_WEB_URL environment variable as optional value

### DIFF
--- a/charts/bindplane/Chart.yaml
+++ b/charts/bindplane/Chart.yaml
@@ -3,7 +3,7 @@ name: bindplane
 description: Bindplane is an observability pipeline.
 type: application
 # The chart's version
-version: 1.30.0
+version: 1.31.0
 # The Bindplane tagged release. If the user does not
 # set the `image.tag` values option, this version is used.
 appVersion: 1.92.0

--- a/charts/bindplane/README.md
+++ b/charts/bindplane/README.md
@@ -1,6 +1,6 @@
 # bindplane
 
-![Version: 1.30.0](https://img.shields.io/badge/Version-1.30.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.92.0](https://img.shields.io/badge/AppVersion-1.92.0-informational?style=flat-square)
+![Version: 1.31.0](https://img.shields.io/badge/Version-1.31.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.92.0](https://img.shields.io/badge/AppVersion-1.92.0-informational?style=flat-square)
 
 Bindplane is an observability pipeline.
 
@@ -85,6 +85,7 @@ Bindplane is an observability pipeline.
 | config.server_url | string | `""` | URI used by clients to communicate with Bindplane. |
 | config.sessions_secret | string | `""` | Sessions Secret to use. Overrides `config.secret`. |
 | config.username | string | `""` | Username to use. Overrides `config.secret`. |
+| config.web_url | string | `""` | External URL used for web user invitation links and other user-facing features. |
 | containerSecurityContext | object | `{"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":65534}` | The Container's securityContext: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container. |
 | dev.bindplane.auth.auth0.audience | string | `""` |  |
 | dev.bindplane.auth.auth0.clientID | string | `""` |  |

--- a/charts/bindplane/templates/bindplane-jobs.yaml
+++ b/charts/bindplane/templates/bindplane-jobs.yaml
@@ -118,6 +118,14 @@ spec:
               {{- else }}
               value: http://{{ include "bindplane.fullname" . }}.{{ .Release.Namespace }}:3001
               {{- end }}
+            - name: BINDPLANE_WEB_URL
+              {{- if .Values.config.web_url }}
+              value: {{ .Values.config.web_url }}
+              {{- else if .Values.config.server_url }}
+              value: {{ .Values.config.server_url }}
+              {{- else }}
+              value: http://{{ include "bindplane.fullname" . }}.{{ .Release.Namespace }}:3001
+              {{- end }}
             {{ if eq .Values.auth.type "system" }}
             - name: BINDPLANE_USERNAME
               {{- if  .Values.config.username }}

--- a/charts/bindplane/templates/bindplane-nats.yaml
+++ b/charts/bindplane/templates/bindplane-nats.yaml
@@ -128,6 +128,14 @@ spec:
               {{- else }}
               value: http://{{ include "bindplane.fullname" . }}.{{ .Release.Namespace }}:3001
               {{- end }}
+            - name: BINDPLANE_WEB_URL
+              {{- if .Values.config.web_url }}
+              value: {{ .Values.config.web_url }}
+              {{- else if .Values.config.server_url }}
+              value: {{ .Values.config.server_url }}
+              {{- else }}
+              value: http://{{ include "bindplane.fullname" . }}.{{ .Release.Namespace }}:3001
+              {{- end }}
             {{ if eq .Values.auth.type "system" }}
             - name: BINDPLANE_USERNAME
               {{- if  .Values.config.username }}

--- a/charts/bindplane/templates/bindplane.yaml
+++ b/charts/bindplane/templates/bindplane.yaml
@@ -133,6 +133,14 @@ spec:
               {{- else }}
               value: http://{{ include "bindplane.fullname" . }}.{{ .Release.Namespace }}:3001
               {{- end }}
+            - name: BINDPLANE_WEB_URL
+              {{- if .Values.config.web_url }}
+              value: {{ .Values.config.web_url }}
+              {{- else if .Values.config.server_url }}
+              value: {{ .Values.config.server_url }}
+              {{- else }}
+              value: http://{{ include "bindplane.fullname" . }}.{{ .Release.Namespace }}:3001
+              {{- end }}
             {{ if eq .Values.auth.type "system" }}
             - name: BINDPLANE_USERNAME
               {{- if  .Values.config.username }}

--- a/charts/bindplane/values.yaml
+++ b/charts/bindplane/values.yaml
@@ -312,6 +312,12 @@ config:
   # It will eventually be removed when support for older versions of Bindplane is removed from this chart.
   remote_url: ""
 
+  # The external web URL used for user-facing features like invitation links.
+  # This is typically your ingress or load balancer URL (e.g., https://bindplane.my-corp.net).
+  # If not set, defaults to the server_url value.
+  # -- External URL used for web user invitation links and other user-facing features.
+  web_url: ""
+
   # kubectl -n <namesapce> create secret generic <name> \
   #   --from-literal=username=myuser \
   #   --from-literal=password=mypassword \

--- a/test/cases/ingress/values.yaml
+++ b/test/cases/ingress/values.yaml
@@ -4,6 +4,7 @@ config:
   password: bppass
   sessions_secret: 4484766F-5016-4077-B8E0-0DE1D637854B
   server_url: http://bindplane.local:80
+  web_url: https://bindplane.external.com
   licenseUseSecret: true
 
 # Ingress


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

A new `web_url` value has been added to expose the [BINDPLANE_WEB_URL](https://docs.bindplane.com/configuration/bindplane#web-url) environment variable. If not set, this defaults to the `server_url` value.

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
- [ ] Changes to ports, services, or other networking have been tested with **istio**
