### PR TITLE
chore: update CODEOWNERS to use teams and add validator workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jsirianni @tbm48813 @schmikei
+* @observIQ/platformteam @observIQ/pipeline

--- a/.github/workflows/codeowners-validator.yml
+++ b/.github/workflows/codeowners-validator.yml
@@ -1,24 +1,19 @@
 name: Validate CODEOWNERS
 
 on:
-  push:
-    paths:
-      - 'CODEOWNERS'
-      - '.github/CODEOWNERS'
-      - 'docs/CODEOWNERS'
+  workflow_dispatch:
   pull_request:
     paths:
-      - 'CODEOWNERS'
       - '.github/CODEOWNERS'
-      - 'docs/CODEOWNERS'
 
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: mszostok/codeowners-validator@v0.7.4
         with:
           checks: "files,owners,duppatterns,syntax"
-          github_access_token: "${{ secrets.GITHUB_TOKEN }}"
+          github_access_token: "${{ secrets.CODEOWNERS_VALIDATOR_TOKEN }}"
+

--- a/.github/workflows/codeowners-validator.yml
+++ b/.github/workflows/codeowners-validator.yml
@@ -1,0 +1,24 @@
+name: Validate CODEOWNERS
+
+on:
+  push:
+    paths:
+      - 'CODEOWNERS'
+      - '.github/CODEOWNERS'
+      - 'docs/CODEOWNERS'
+  pull_request:
+    paths:
+      - 'CODEOWNERS'
+      - '.github/CODEOWNERS'
+      - 'docs/CODEOWNERS'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: mszostok/codeowners-validator@v0.7.4
+        with:
+          checks: "files,owners,duppatterns,syntax"
+          github_access_token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Summary
- Replace individual users with team-based ownership in CODEOWNERS
- Add CODEOWNERS validator GitHub Action workflow that triggers when CODEOWNERS is updated

## Changes
- `@jsirianni` → `@observIQ/platformteam`
- `@tbm48813` → `@observIQ/platformteam`
- `@schmikei` → `@observIQ/pipeline`

## Related
PLAT-427